### PR TITLE
fix: add idempotency guard to prevent duplicate content script listeners

### DIFF
--- a/content.js
+++ b/content.js
@@ -45,12 +45,15 @@ async function getThemeTokens() {
   return { tokens: config[mode] || config.light, accent: config.accent, color, mode };
 }
 
-chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
-  if (message?.type === "open-tab-search") {
-    openTabSearch(message.tabs);
-    sendResponse({ ok: true });
-  }
-});
+if (!window.__aiTabOrganizerListenerRegistered__) {
+  window.__aiTabOrganizerListenerRegistered__ = true;
+  chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
+    if (message?.type === "open-tab-search") {
+      openTabSearch(message.tabs);
+      sendResponse({ ok: true });
+    }
+  });
+}
 
 async function openTabSearch(prefetchedTabs) {
   const existing = document.getElementById(OVERLAY_ID);


### PR DESCRIPTION
## Summary
- Wraps the `chrome.runtime.onMessage.addListener` call in `content.js` with a `window.__aiTabOrganizerListenerRegistered__` guard so the listener is only registered once, even if the content script is injected multiple times.
- Prevents the tab search panel from flashing open then immediately closing due to duplicate `open-tab-search` handlers toggling the panel twice.

Closes #4

## Test plan
- [ ] Open the extension, trigger the tab search — verify the panel opens and stays open
- [ ] Close and reopen the panel — verify it toggles correctly without flashing
- [ ] Navigate to a new page and trigger tab search — verify only one listener is active (panel does not flash)

🤖 Generated with [Claude Code](https://claude.com/claude-code)