### PR TITLE
fix: use Promise.allSettled for batch tab operations to handle partial failures

### DIFF
--- a/background.js
+++ b/background.js
@@ -258,8 +258,11 @@ async function applyBatchAction(message) {
     return { ok: false, error: "还没有选中任何标签页。" };
   }
 
-  const tabs = await Promise.all(tabIds.map((tabId) => chrome.tabs.get(tabId)));
-  const validTabs = tabs.filter((tab) => tab.id);
+  const results = await Promise.allSettled(tabIds.map((tabId) => chrome.tabs.get(tabId)));
+  const validTabs = results
+    .filter((result) => result.status === "fulfilled")
+    .map((result) => result.value)
+    .filter((tab) => tab.id);
 
   if (validTabs.length === 0) {
     return { ok: false, error: "选中的标签页已经不存在了。" };


### PR DESCRIPTION
## Summary

- Replace `Promise.all` with `Promise.allSettled` in `applyBatchAction` so that a single closed/invalid tab no longer causes the entire batch operation to fail
- Filter settled results for fulfilled promises only, then continue with the existing `validTabs` logic

Closes #2

## Test plan

- [ ] Select multiple tabs including one that gets closed before applying the action
- [ ] Verify the batch operation succeeds for the remaining valid tabs
- [ ] Verify that if all selected tabs are invalid, the "选中的标签页已经不存在了" error is returned

🤖 Generated with [Claude Code](https://claude.com/claude-code)