### PR TITLE
fix: check response.ok before updating UI on tab actions

### DIFF
--- a/content.js
+++ b/content.js
@@ -991,7 +991,8 @@ async function openTabSearch(prefetchedTabs) {
     }
 
     if (action === "close") {
-      await chrome.runtime.sendMessage({ type: "close-tab", tabId: entry.tabId });
+      const response = await chrome.runtime.sendMessage({ type: "close-tab", tabId: entry.tabId });
+      if (!response?.ok) return;
       tabs = tabs.filter((tab) => tab.id !== entry.tabId);
       hoveredIndex = null;
       selectedAction = null;
@@ -1000,7 +1001,8 @@ async function openTabSearch(prefetchedTabs) {
     }
 
     if (action === "bookmark_close") {
-      await chrome.runtime.sendMessage({ type: "bookmark-and-close-tab", tabId: entry.tabId });
+      const response = await chrome.runtime.sendMessage({ type: "bookmark-and-close-tab", tabId: entry.tabId });
+      if (!response?.ok) return;
       tabs = tabs.filter((tab) => tab.id !== entry.tabId);
       hoveredIndex = null;
       selectedAction = null;
@@ -1090,13 +1092,15 @@ async function openTabSearch(prefetchedTabs) {
       return;
     }
 
-    await chrome.runtime.sendMessage({
+    const response = await chrome.runtime.sendMessage({
       type: "apply-batch-action",
       action,
       tabIds: (naturalPreview?.tabs || []).map((tab) => tab.id),
       query: naturalPreview?.query || input.value.trim(),
       label: naturalPreview?.suggestedLabel || ""
     });
+
+    if (!response?.ok) return;
 
     close();
   }

--- a/search.js
+++ b/search.js
@@ -771,7 +771,11 @@ async function initialize() {
     }
 
     if (action === "close") {
-      await chrome.runtime.sendMessage({ type: "close-tab", tabId: entry.tabId });
+      const response = await chrome.runtime.sendMessage({ type: "close-tab", tabId: entry.tabId });
+      if (!response?.ok) {
+        hint.textContent = response?.error || "关闭标签页失败";
+        return;
+      }
       tabs = tabs.filter((tab) => tab.id !== entry.tabId);
       hoveredIndex = null;
       selectedAction = null;
@@ -780,7 +784,11 @@ async function initialize() {
     }
 
     if (action === "bookmark_close") {
-      await chrome.runtime.sendMessage({ type: "bookmark-and-close-tab", tabId: entry.tabId });
+      const response = await chrome.runtime.sendMessage({ type: "bookmark-and-close-tab", tabId: entry.tabId });
+      if (!response?.ok) {
+        hint.textContent = response?.error || "收藏并关闭失败";
+        return;
+      }
       tabs = tabs.filter((tab) => tab.id !== entry.tabId);
       hoveredIndex = null;
       selectedAction = null;
@@ -892,13 +900,18 @@ async function initialize() {
       return;
     }
 
-    await chrome.runtime.sendMessage({
+    const response = await chrome.runtime.sendMessage({
       type: "apply-batch-action",
       action,
       tabIds: (naturalPreview?.tabs || []).map((tab) => tab.id),
       query: naturalPreview?.query || input.value.trim(),
       label: naturalPreview?.suggestedLabel || ""
     });
+
+    if (!response?.ok) {
+      hint.textContent = response?.error || "批量操作失败";
+      return;
+    }
 
     window.close();
   }


### PR DESCRIPTION
## Summary
- Check `response?.ok` before updating UI state in `search.js` and `content.js` for `close`, `bookmark_close`, and natural batch actions
- In `search.js`, show error message in `hint.textContent` when background operation fails
- In `content.js`, silently skip the UI update when background operation fails

Closes #3

## Test plan
- [ ] Trigger a `close` action when the background script returns a failure — verify the tab stays in the list and an error hint is shown (search.js) or the list is unchanged (content.js)
- [ ] Trigger a `bookmark_close` action when the background script returns a failure — same verification
- [ ] Trigger a natural batch action when the background script returns a failure — verify the window does not close and an error hint is shown (search.js) or the overlay stays open (content.js)
- [ ] Verify all three actions still work correctly when the background script succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)