### PR TITLE
fix: pass explicit windowId from standalone search popup

### DIFF
--- a/background.js
+++ b/background.js
@@ -48,7 +48,7 @@ async function handleRuntimeMessage(message) {
     case "get-organization-state":
       return { ok: true, state: organizationState };
     case "run-ai-organization":
-      return await organizeTabsWithAI();
+      return await organizeTabsWithAI(message.windowId);
     case "run-tab-search":
       await openTabSearch();
       return { ok: true };
@@ -70,7 +70,7 @@ async function handleRuntimeMessage(message) {
       await bookmarkAndCloseTab(message.tabId);
       return { ok: true };
     case "preview-batch-tabs":
-      return await previewBatchTabs(message.query);
+      return await previewBatchTabs(message.query, message.windowId);
     case "apply-batch-action":
       return await applyBatchAction(message);
     default:
@@ -90,7 +90,7 @@ async function openTabSearch() {
   }
 
   if (isSearchPanelBlockedTab(tab.url)) {
-    await openStandaloneSearchWindow();
+    await openStandaloneSearchWindow(tab.windowId);
     return;
   }
 
@@ -107,21 +107,25 @@ async function openTabSearch() {
 
       await chrome.tabs.sendMessage(tab.id, payload);
     } catch (_innerError) {
-      await openStandaloneSearchWindow();
+      await openStandaloneSearchWindow(tab.windowId);
     }
   }
 }
 
-async function openStandaloneSearchWindow() {
+async function openStandaloneSearchWindow(sourceWindowId) {
+  const url = new URL(chrome.runtime.getURL("search.html"));
+  if (sourceWindowId) {
+    url.searchParams.set("sourceWindowId", sourceWindowId);
+  }
   await chrome.windows.create({
-    url: chrome.runtime.getURL("search.html"),
+    url: url.toString(),
     type: "popup",
     width: 820,
     height: 720
   });
 }
 
-async function organizeTabsWithAI() {
+async function organizeTabsWithAI(windowId) {
   if (organizationState.busy) {
     return { ok: false, error: "已有一次整理正在进行中。" };
   }
@@ -148,7 +152,7 @@ async function organizeTabsWithAI() {
       detail: "正在分析当前窗口的未固定网页标签页"
     });
 
-    const windowTabs = await chrome.tabs.query({ currentWindow: true });
+    const windowTabs = await chrome.tabs.query(windowId ? { windowId } : { currentWindow: true });
     const candidateTabs = getCandidateTabs(windowTabs);
     pushLog(`读取到 ${candidateTabs.length} 个可整理标签页`);
 
@@ -215,7 +219,7 @@ async function organizeTabsWithAI() {
   }
 }
 
-async function previewBatchTabs(query) {
+async function previewBatchTabs(query, windowId) {
   const trimmedQuery = String(query || "").trim();
 
   if (!trimmedQuery) {
@@ -228,7 +232,7 @@ async function previewBatchTabs(query) {
     return { ok: false, error: "请先在设置页填写 API Key。" };
   }
 
-  const currentTabs = getCandidateTabs(await chrome.tabs.query({ currentWindow: true }));
+  const currentTabs = getCandidateTabs(await chrome.tabs.query(windowId ? { windowId } : { currentWindow: true }));
 
   if (currentTabs.length === 0) {
     return { ok: false, error: "当前窗口没有可操作的网页标签页。" };

--- a/search.js
+++ b/search.js
@@ -15,6 +15,9 @@ async function initialize() {
     return;
   }
 
+  const sourceWindowId = new URLSearchParams(window.location.search).get("sourceWindowId");
+  const targetWindowId = sourceWindowId ? Number(sourceWindowId) : undefined;
+
   const response = await chrome.runtime.sendMessage({ type: "get-tabs" });
 
   if (!response?.ok) {
@@ -82,7 +85,7 @@ async function initialize() {
     setToolbarButtonBusy(arrangeButton, true, "整理中…");
 
     try {
-      await chrome.runtime.sendMessage({ type: "run-ai-organization" });
+      await chrome.runtime.sendMessage({ type: "run-ai-organization", windowId: targetWindowId });
       window.close();
     } finally {
       setToolbarButtonBusy(arrangeButton, false, "整理Tab");
@@ -510,7 +513,7 @@ async function initialize() {
         preference: preferenceField.input.value,
         experimentalTitleRewriteEnabled: toggleField.input.checked
       });
-      const response = await chrome.runtime.sendMessage({ type: "run-ai-organization" });
+      const response = await chrome.runtime.sendMessage({ type: "run-ai-organization", windowId: targetWindowId });
       status.textContent = response?.summary || response?.reason || (response?.ok ? "已开始" : response?.error || "整理失败");
       if (response?.ok || response?.skipped) {
         window.close();
@@ -739,7 +742,7 @@ async function initialize() {
 
   async function executeEntryAction(entry, action) {
     if (entry.kind === "command" && entry.command === "arrange") {
-      await chrome.runtime.sendMessage({ type: "run-ai-organization" });
+      await chrome.runtime.sendMessage({ type: "run-ai-organization", windowId: targetWindowId });
       window.close();
       return;
     }
@@ -810,7 +813,7 @@ async function initialize() {
     updateHint();
     rebuildRows();
 
-    const response = await chrome.runtime.sendMessage({ type: "preview-batch-tabs", query });
+    const response = await chrome.runtime.sendMessage({ type: "preview-batch-tabs", query, windowId: targetWindowId });
     isNaturalLoading = false;
 
     if (!response?.ok) {
@@ -897,7 +900,8 @@ async function initialize() {
       action,
       tabIds: (naturalPreview?.tabs || []).map((tab) => tab.id),
       query: naturalPreview?.query || input.value.trim(),
-      label: naturalPreview?.suggestedLabel || ""
+      label: naturalPreview?.suggestedLabel || "",
+      windowId: targetWindowId
     });
 
     window.close();


### PR DESCRIPTION
## Summary
- When `search.html` opens as a standalone popup window (fallback for restricted pages like `chrome://extensions`), tab organization and batch actions used `chrome.tabs.query({ currentWindow: true })` in the background service worker, which could resolve to the search popup itself instead of the user's original browser window.
- Now the source window ID is passed as a URL parameter (`sourceWindowId`) when opening the standalone search window, and `search.js` forwards it as `windowId` in all relevant messages (`run-ai-organization`, `preview-batch-tabs`, `apply-batch-action`).
- `background.js` uses the explicit `windowId` when provided, falling back to `{ currentWindow: true }` for non-standalone contexts.

## Test plan
- [ ] Open a restricted page (e.g. `chrome://extensions`) and trigger the tab search — it should open the standalone popup with `?sourceWindowId=...` in the URL
- [ ] From the standalone popup, click "整理Tab" and verify it organizes tabs in the original browser window, not the popup
- [ ] From the standalone popup, use natural language batch search and verify previewed tabs come from the original window
- [ ] Execute a batch action (group/close/bookmark) and verify it operates on the correct window's tabs
- [ ] Verify normal (non-standalone) search panel still works correctly (no `windowId` in message, falls back to `currentWindow: true`)

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)