### PR TITLE
feat: 增加 provider 预置并统一独立设置页入口

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,20 @@
 3. 点击“加载已解压的扩展程序”
 4. 选择这个目录
 5. 打开扩展弹窗，点击“打开设置”
-6. 填写 AI 接口地址、API Key、模型名
+6. 选择服务商预置，或手动填写 AI 接口地址、API Key、模型名
 7. 回到弹窗点击“开始整理”
+
+当前内置了这些常见预置：
+
+- OpenAI
+- OpenRouter
+- Groq
+- DeepSeek
+- 硅基流动
+- 阿里云百炼（OpenAI 兼容入口）
+- 自定义
+
+这些预置只覆盖兼容 OpenAI Chat Completions 的接口，切换后会自动带入推荐地址和常见模型列表；如果列表里没有你要的模型，也可以切到自定义模型继续填写。
 
 接口地址可以填：
 
@@ -57,6 +69,7 @@
 ## 文件说明
 
 - `manifest.json`: 扩展权限、弹窗、设置页、快捷键
+- `ai-provider-config.js`: AI 服务商预置和接口归一化逻辑
 - `background.js`: AI 调用、排序和 tab group 应用逻辑
 - `background.js`: 也负责自然语言筛选 tab、批量分组/删除/书签
 - `content.js`: 页面内标签页搜索面板

--- a/ai-provider-config.js
+++ b/ai-provider-config.js
@@ -1,0 +1,333 @@
+(function attachAIProviderConfig(root, factory) {
+  const api = factory();
+
+  root.AIProviderConfig = api;
+
+  if (typeof module !== "undefined" && module.exports) {
+    module.exports = api;
+  }
+})(typeof globalThis !== "undefined" ? globalThis : this, function createAIProviderConfig() {
+  const AI_PROVIDER_STORAGE_KEY = "aiProviderPresetId";
+  const CUSTOM_AI_PROVIDER_ID = "custom";
+  const CUSTOM_AI_MODEL_OPTION_VALUE = "__custom_model__";
+  const DEFAULT_AI_PROVIDER_ID = "openai";
+  const DEFAULT_AI_ENDPOINT = "https://api.openai.com/v1/chat/completions";
+  const DEFAULT_AI_MODEL = "gpt-4.1-mini";
+  const DEFAULT_CUSTOM_API_KEY_PLACEHOLDER = "填写兼容 OpenAI 的 API Key";
+
+  const AI_PROVIDER_PRESETS = Object.freeze([
+    Object.freeze({
+      id: "openai",
+      label: "OpenAI",
+      endpoint: "https://api.openai.com/v1/chat/completions",
+      defaultModel: "gpt-4.1-mini",
+      apiKeyPlaceholder: "填写 OpenAI API Key",
+      models: [
+        { value: "gpt-4.1-mini", label: "gpt-4.1-mini" },
+        { value: "gpt-4.1", label: "gpt-4.1" },
+        { value: "gpt-4.1-nano", label: "gpt-4.1-nano" },
+        { value: "gpt-4o-mini", label: "gpt-4o-mini" },
+        { value: "gpt-4o", label: "gpt-4o" }
+      ]
+    }),
+    Object.freeze({
+      id: "openrouter",
+      label: "OpenRouter",
+      endpoint: "https://openrouter.ai/api/v1/chat/completions",
+      defaultModel: "openai/gpt-4.1-mini",
+      apiKeyPlaceholder: "填写 OpenRouter API Key",
+      models: [
+        { value: "openai/gpt-4.1-mini", label: "openai/gpt-4.1-mini" },
+        { value: "openai/gpt-4.1", label: "openai/gpt-4.1" },
+        { value: "anthropic/claude-3.7-sonnet", label: "anthropic/claude-3.7-sonnet" },
+        { value: "google/gemini-2.5-flash", label: "google/gemini-2.5-flash" },
+        { value: "deepseek/deepseek-chat-v3-0324", label: "deepseek/deepseek-chat-v3-0324" }
+      ]
+    }),
+    Object.freeze({
+      id: "groq",
+      label: "Groq",
+      endpoint: "https://api.groq.com/openai/v1/chat/completions",
+      defaultModel: "llama-3.3-70b-versatile",
+      apiKeyPlaceholder: "填写 Groq API Key",
+      models: [
+        { value: "llama-3.3-70b-versatile", label: "llama-3.3-70b-versatile" },
+        { value: "llama-3.1-8b-instant", label: "llama-3.1-8b-instant" },
+        { value: "mixtral-8x7b-32768", label: "mixtral-8x7b-32768" }
+      ]
+    }),
+    Object.freeze({
+      id: "deepseek",
+      label: "DeepSeek",
+      endpoint: "https://api.deepseek.com/v1/chat/completions",
+      defaultModel: "deepseek-chat",
+      apiKeyPlaceholder: "填写 DeepSeek API Key",
+      models: [
+        { value: "deepseek-chat", label: "deepseek-chat" },
+        { value: "deepseek-reasoner", label: "deepseek-reasoner" }
+      ]
+    }),
+    Object.freeze({
+      id: "siliconflow",
+      label: "硅基流动",
+      endpoint: "https://api.siliconflow.cn/v1/chat/completions",
+      defaultModel: "Qwen/Qwen2.5-7B-Instruct",
+      apiKeyPlaceholder: "填写硅基流动 API Key",
+      models: [
+        { value: "Qwen/Qwen2.5-7B-Instruct", label: "Qwen/Qwen2.5-7B-Instruct" },
+        { value: "deepseek-ai/DeepSeek-V3", label: "deepseek-ai/DeepSeek-V3" },
+        { value: "deepseek-ai/DeepSeek-R1", label: "deepseek-ai/DeepSeek-R1" },
+        { value: "Qwen/QwQ-32B", label: "Qwen/QwQ-32B" }
+      ]
+    }),
+    Object.freeze({
+      id: "dashscope",
+      label: "阿里云百炼",
+      endpoint: "https://dashscope.aliyuncs.com/compatible-mode/v1/chat/completions",
+      defaultModel: "qwen-plus",
+      apiKeyPlaceholder: "填写阿里云百炼 API Key",
+      models: [
+        { value: "qwen-plus", label: "qwen-plus" },
+        { value: "qwen-turbo", label: "qwen-turbo" },
+        { value: "qwen-max", label: "qwen-max" }
+      ]
+    }),
+    Object.freeze({
+      id: CUSTOM_AI_PROVIDER_ID,
+      label: "自定义",
+      endpoint: DEFAULT_AI_ENDPOINT,
+      defaultModel: DEFAULT_AI_MODEL,
+      apiKeyPlaceholder: DEFAULT_CUSTOM_API_KEY_PLACEHOLDER,
+      models: []
+    })
+  ]);
+
+  const presetMap = new Map(AI_PROVIDER_PRESETS.map((preset) => [preset.id, preset]));
+
+  function getAIProviderPreset(providerId) {
+    return presetMap.get(providerId) || presetMap.get(CUSTOM_AI_PROVIDER_ID);
+  }
+
+  function normalizeAIEndpoint(endpoint) {
+    const value = String(endpoint || "").trim();
+
+    if (!value) {
+      return DEFAULT_AI_ENDPOINT;
+    }
+
+    try {
+      const url = new URL(value);
+      const pathname = trimTrailingSlash(url.pathname);
+
+      if (!pathname) {
+        url.pathname = "/v1/chat/completions";
+        return url.toString();
+      }
+
+      if (pathname.endsWith("/chat/completions")) {
+        url.pathname = pathname;
+        return url.toString();
+      }
+
+      const segments = pathname.split("/").filter(Boolean);
+      const lastSegment = segments[segments.length - 1] || "";
+
+      if (/^v\d+$/i.test(lastSegment)) {
+        url.pathname = `/${segments.join("/")}/chat/completions`;
+      } else {
+        url.pathname = pathname;
+      }
+
+      return url.toString();
+    } catch (_error) {
+      return value;
+    }
+  }
+
+  function detectAIProviderPreset(endpoint) {
+    const normalized = normalizeAIEndpoint(endpoint);
+
+    try {
+      const target = stripCompletionPath(new URL(normalized));
+
+      for (const preset of AI_PROVIDER_PRESETS) {
+        if (preset.id === CUSTOM_AI_PROVIDER_ID) {
+          continue;
+        }
+
+        const presetBase = stripCompletionPath(new URL(preset.endpoint));
+
+        if (target === presetBase) {
+          return preset.id;
+        }
+      }
+    } catch (_error) {
+      return CUSTOM_AI_PROVIDER_ID;
+    }
+
+    return CUSTOM_AI_PROVIDER_ID;
+  }
+
+  function applyAIProviderPreset(providerId, currentDraft) {
+    const preset = getAIProviderPreset(providerId);
+    const draft = currentDraft || {};
+
+    if (preset.id === CUSTOM_AI_PROVIDER_ID) {
+      return {
+        ...draft,
+        providerId: CUSTOM_AI_PROVIDER_ID,
+        endpoint: normalizeAIEndpoint(draft.endpoint || DEFAULT_AI_ENDPOINT),
+        model: String(draft.model || "").trim() || DEFAULT_AI_MODEL,
+        apiKeyPlaceholder: preset.apiKeyPlaceholder
+      };
+    }
+
+    return {
+      ...draft,
+      providerId: preset.id,
+      endpoint: preset.endpoint,
+      model: preset.defaultModel,
+      apiKeyPlaceholder: preset.apiKeyPlaceholder
+    };
+  }
+
+  function resolveAISettingsDraft(stored) {
+    const source = stored || {};
+    const endpoint = normalizeAIEndpoint(source.aiEndpoint || DEFAULT_AI_ENDPOINT);
+    const savedProviderId = String(source[AI_PROVIDER_STORAGE_KEY] || "").trim();
+    const providerId = presetMap.has(savedProviderId) ? savedProviderId : detectAIProviderPreset(endpoint);
+    const preset = getAIProviderPreset(providerId);
+
+    return {
+      providerId,
+      endpoint,
+      apiKey: source.aiApiKey || "",
+      apiKeyPlaceholder: preset.apiKeyPlaceholder,
+      model: String(source.aiModel || "").trim() || preset.defaultModel || DEFAULT_AI_MODEL,
+      preference: source.aiPreference || "",
+      experimentalTitleRewriteEnabled: Boolean(source.experimentalTitleRewriteEnabled)
+    };
+  }
+
+  function getAIModelOptions(providerId) {
+    const preset = getAIProviderPreset(providerId);
+    return Array.isArray(preset.models) ? preset.models.slice() : [];
+  }
+
+  function resolveAIModelSelection(providerId, model) {
+    const preset = getAIProviderPreset(providerId);
+    const trimmedModel = String(model || "").trim();
+    const options = getAIModelOptions(providerId);
+    const fallbackModel = preset.defaultModel || DEFAULT_AI_MODEL;
+    const matched = options.find((item) => item.value === trimmedModel);
+
+    if (providerId === CUSTOM_AI_PROVIDER_ID) {
+      return {
+        options,
+        selectedValue: CUSTOM_AI_MODEL_OPTION_VALUE,
+        customValue: trimmedModel || fallbackModel
+      };
+    }
+
+    if (matched) {
+      return {
+        options,
+        selectedValue: matched.value,
+        customValue: ""
+      };
+    }
+
+    if (!trimmedModel) {
+      return {
+        options,
+        selectedValue: fallbackModel,
+        customValue: ""
+      };
+    }
+
+    return {
+      options,
+      selectedValue: CUSTOM_AI_MODEL_OPTION_VALUE,
+      customValue: trimmedModel
+    };
+  }
+
+  function populateAIProviderSelect(select) {
+    if (!select) {
+      return;
+    }
+
+    select.textContent = "";
+
+    AI_PROVIDER_PRESETS.forEach((preset) => {
+      const option = select.ownerDocument.createElement("option");
+      option.value = preset.id;
+      option.textContent = preset.label;
+      select.appendChild(option);
+    });
+  }
+
+  function populateAIModelSelect(select, providerId, currentModel) {
+    if (!select) {
+      return;
+    }
+
+    const selection = resolveAIModelSelection(providerId, currentModel);
+    select.textContent = "";
+
+    selection.options.forEach((item) => {
+      const option = select.ownerDocument.createElement("option");
+      option.value = item.value;
+      option.textContent = item.label;
+      select.appendChild(option);
+    });
+
+    const customOption = select.ownerDocument.createElement("option");
+    customOption.value = CUSTOM_AI_MODEL_OPTION_VALUE;
+    customOption.textContent = "自定义模型";
+    select.appendChild(customOption);
+    select.value = selection.selectedValue;
+  }
+
+  function updateAIKeyPlaceholder(input, providerId) {
+    if (!input) {
+      return;
+    }
+
+    input.placeholder = getAIProviderPreset(providerId).apiKeyPlaceholder;
+  }
+
+  function stripCompletionPath(url) {
+    return `${url.origin}${trimTrailingSlash(url.pathname).replace(/\/chat\/completions$/i, "")}`;
+  }
+
+  function trimTrailingSlash(pathname) {
+    const normalized = String(pathname || "").trim();
+
+    if (!normalized || normalized === "/") {
+      return "";
+    }
+
+    return normalized.replace(/\/+$/g, "");
+  }
+
+  return Object.freeze({
+    AI_PROVIDER_STORAGE_KEY,
+    AI_PROVIDER_PRESETS,
+    CUSTOM_AI_MODEL_OPTION_VALUE,
+    CUSTOM_AI_PROVIDER_ID,
+    DEFAULT_AI_ENDPOINT,
+    DEFAULT_AI_MODEL,
+    DEFAULT_CUSTOM_API_KEY_PLACEHOLDER,
+    applyAIProviderPreset,
+    detectAIProviderPreset,
+    getAIModelOptions,
+    getAIProviderPreset,
+    normalizeAIEndpoint,
+    populateAIModelSelect,
+    resolveAIModelSelection,
+    populateAIProviderSelect,
+    resolveAISettingsDraft,
+    updateAIKeyPlaceholder
+  });
+});

--- a/background.js
+++ b/background.js
@@ -102,7 +102,7 @@ async function openTabSearch() {
     try {
       await chrome.scripting.executeScript({
         target: { tabId: tab.id },
-        files: ["content.js"]
+        files: ["ai-provider-config.js", "content.js"]
       });
 
       await chrome.tabs.sendMessage(tab.id, payload);

--- a/content.js
+++ b/content.js
@@ -1,3 +1,16 @@
+const {
+  AI_PROVIDER_STORAGE_KEY,
+  CUSTOM_AI_MODEL_OPTION_VALUE,
+  applyAIProviderPreset,
+  detectAIProviderPreset,
+  normalizeAIEndpoint,
+  populateAIModelSelect,
+  populateAIProviderSelect,
+  resolveAIModelSelection,
+  resolveAISettingsDraft,
+  updateAIKeyPlaceholder
+} = globalThis.AIProviderConfig;
+
 const OVERLAY_ID = "__ai_tab_organizer_search_overlay__";
 const ACTIONS = ["open", "close", "bookmark_close"];
 const NATURAL_BATCH_ACTIONS = [
@@ -610,7 +623,7 @@ async function openTabSearch(prefetchedTabs) {
     });
 
     const helper = document.createElement("div");
-    helper.textContent = "设置主题色、AI接口和整理偏好";
+    helper.textContent = "设置主题色、服务商、AI 接口和整理偏好，切换服务商会带入推荐地址和模型。";
     setStyles(helper, {
       padding: "0 10px",
       fontSize: "12px",
@@ -636,11 +649,15 @@ async function openTabSearch(prefetchedTabs) {
       minHeight: "18px"
     });
 
-    const fields = [
-      createSettingsField("接口地址", "url", "https://api.openai.com/v1/chat/completions", t),
-      createSettingsField("API Key", "password", "sk-...", t),
-      createSettingsField("模型名", "text", "gpt-4.1-mini", t)
-    ];
+    const providerField = createSettingsSelect("服务商", t);
+    populateAIProviderSelect(providerField.input);
+
+    const endpointField = createSettingsField("接口地址", "url", "https://api.openai.com/v1/chat/completions", t);
+    const apiKeyField = createSettingsField("API Key", "password", "sk-...", t);
+    const modelField = createSettingsSelect("模型名", t);
+    const customModelInput = createSettingsStandaloneInput("text", "输入自定义模型名", t);
+    customModelInput.style.display = "none";
+    modelField.wrapper.appendChild(customModelInput);
     const preferenceField = createSettingsTextarea("整理偏好", "例如：工作相关靠前，阅读类折叠，娱乐类靠后。", t);
     const toggleField = createSettingsToggle("实验功能：整理后简化网页标题", "整理后尝试为可注入网页写入更短的临时标题。", t, theme.accent);
 
@@ -655,9 +672,10 @@ async function openTabSearch(prefetchedTabs) {
     const saveButton = createToolbarButton("保存设置", async () => {
       status.textContent = "正在保存…";
       await saveInlineSettings({
-        endpoint: fields[0].input.value,
-        apiKey: fields[1].input.value,
-        model: fields[2].input.value,
+        providerId: providerField.input.value,
+        endpoint: endpointField.input.value,
+        apiKey: apiKeyField.input.value,
+        model: getCurrentModelValue(),
         preference: preferenceField.input.value,
         experimentalTitleRewriteEnabled: toggleField.input.checked
       });
@@ -667,9 +685,10 @@ async function openTabSearch(prefetchedTabs) {
     const runButton = createToolbarButton("保存并立即整理标签页", async () => {
       status.textContent = "保存并开始整理…";
       await saveInlineSettings({
-        endpoint: fields[0].input.value,
-        apiKey: fields[1].input.value,
-        model: fields[2].input.value,
+        providerId: providerField.input.value,
+        endpoint: endpointField.input.value,
+        apiKey: apiKeyField.input.value,
+        model: getCurrentModelValue(),
         preference: preferenceField.input.value,
         experimentalTitleRewriteEnabled: toggleField.input.checked
       });
@@ -686,24 +705,77 @@ async function openTabSearch(prefetchedTabs) {
     shell.appendChild(title);
     shell.appendChild(helper);
     shell.appendChild(themeRow);
-    fields.forEach((field) => shell.appendChild(field.wrapper));
+    shell.appendChild(providerField.wrapper);
+    shell.appendChild(endpointField.wrapper);
+    shell.appendChild(apiKeyField.wrapper);
+    shell.appendChild(modelField.wrapper);
     shell.appendChild(preferenceField.wrapper);
     shell.appendChild(toggleField.wrapper);
     shell.appendChild(actionRow);
     shell.appendChild(status);
     list.appendChild(shell);
 
+    providerField.input.addEventListener("change", () => {
+      const nextDraft = applyAIProviderPreset(providerField.input.value, {
+        endpoint: endpointField.input.value,
+        apiKey: apiKeyField.input.value,
+        model: getCurrentModelValue(),
+        preference: preferenceField.input.value,
+        experimentalTitleRewriteEnabled: toggleField.input.checked
+      });
+
+      endpointField.input.value = nextDraft.endpoint;
+      syncModelControls(nextDraft.providerId, nextDraft.model);
+      updateAIKeyPlaceholder(apiKeyField.input, nextDraft.providerId);
+    });
+
+    endpointField.input.addEventListener("input", () => {
+      providerField.input.value = detectAIProviderPreset(endpointField.input.value);
+      syncModelControls(providerField.input.value, getCurrentModelValue());
+      updateAIKeyPlaceholder(apiKeyField.input, providerField.input.value);
+    });
+
+    modelField.input.addEventListener("change", () => {
+      const isCustom = modelField.input.value === CUSTOM_AI_MODEL_OPTION_VALUE;
+
+      if (isCustom && !customModelInput.value.trim()) {
+        customModelInput.value = modelField.input.dataset.selectedPresetModel || "";
+      }
+
+      if (!isCustom) {
+        modelField.input.dataset.selectedPresetModel = modelField.input.value;
+      }
+
+      customModelInput.style.display = isCustom ? "block" : "none";
+    });
+
     loadInlineSettings()
       .then((settings) => {
-        fields[0].input.value = settings.endpoint;
-        fields[1].input.value = settings.apiKey;
-        fields[2].input.value = settings.model;
+        providerField.input.value = settings.providerId;
+        endpointField.input.value = settings.endpoint;
+        apiKeyField.input.value = settings.apiKey;
+        syncModelControls(settings.providerId, settings.model);
         preferenceField.input.value = settings.preference;
         toggleField.input.checked = settings.experimentalTitleRewriteEnabled;
+        updateAIKeyPlaceholder(apiKeyField.input, settings.providerId);
       })
       .catch((error) => {
         status.textContent = error instanceof Error ? error.message : "读取设置失败";
       });
+
+    function syncModelControls(providerId, modelValue) {
+      const selection = resolveAIModelSelection(providerId, modelValue);
+      populateAIModelSelect(modelField.input, providerId, modelValue);
+      modelField.input.value = selection.selectedValue;
+      modelField.input.dataset.selectedPresetModel =
+        selection.selectedValue === CUSTOM_AI_MODEL_OPTION_VALUE ? selection.options[0]?.value || "" : selection.selectedValue;
+      customModelInput.value = selection.customValue;
+      customModelInput.style.display = selection.selectedValue === CUSTOM_AI_MODEL_OPTION_VALUE ? "block" : "none";
+    }
+
+    function getCurrentModelValue() {
+      return modelField.input.value === CUSTOM_AI_MODEL_OPTION_VALUE ? customModelInput.value.trim() : modelField.input.value;
+    }
   }
 
   function createRow(entry, index) {
@@ -1224,7 +1296,7 @@ function buildEntries(tabs, query) {
       kind: "command",
       command: "settings",
       title: "设置",
-      subtitle: "设置主题色、AI接口和整理偏好"
+      subtitle: "设置主题色、服务商、AI 接口和整理偏好"
     });
   }
 
@@ -1396,6 +1468,51 @@ function createSettingsField(label, type, placeholder, tokens) {
     border: `1px solid ${settingsBorderC}`,
     borderRadius: "12px",
     padding: "10px 12px",
+    paddingRight: "40px",
+    outline: "none",
+    background: settingsInputBg,
+    appearance: "none",
+    WebkitAppearance: "none",
+    backgroundImage:
+      "url(\"data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12' fill='none'%3E%3Cpath d='M2 4.5L6 8L10 4.5' stroke='%236d6d67' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E\")",
+    backgroundRepeat: "no-repeat",
+    backgroundPosition: "right 14px center",
+    backgroundSize: "12px 12px",
+    color: fg,
+    fontSize: "13px"
+  });
+
+  wrapper.appendChild(text);
+  wrapper.appendChild(input);
+  return { wrapper, input };
+}
+
+function createSettingsSelect(label, tokens) {
+  const fg = (tokens && tokens.text) || "#0f172a";
+  const inputBg = (tokens && tokens.inputBg) || "rgba(255, 255, 255, 0.42)";
+  const borderC = (tokens && tokens.border) || "rgba(15, 23, 42, 0.10)";
+  const settingsInputBg = inputBg.replace(/[\d.]+\)$/, "0.42)");
+  const settingsBorderC = borderC.replace(/[\d.]+\)$/, "0.10)");
+  const wrapper = document.createElement("label");
+  setStyles(wrapper, {
+    display: "flex",
+    flexDirection: "column",
+    gap: "6px",
+    padding: "0 10px",
+    fontSize: "12px",
+    color: fg
+  });
+
+  const text = document.createElement("span");
+  text.textContent = label;
+  setStyles(text, { fontWeight: "700" });
+
+  const input = document.createElement("select");
+  setStyles(input, {
+    width: "100%",
+    border: `1px solid ${settingsBorderC}`,
+    borderRadius: "12px",
+    padding: "10px 12px",
     outline: "none",
     background: settingsInputBg,
     color: fg,
@@ -1405,6 +1522,28 @@ function createSettingsField(label, type, placeholder, tokens) {
   wrapper.appendChild(text);
   wrapper.appendChild(input);
   return { wrapper, input };
+}
+
+function createSettingsStandaloneInput(type, placeholder, tokens) {
+  const fg = (tokens && tokens.text) || "#0f172a";
+  const inputBg = (tokens && tokens.inputBg) || "rgba(255, 255, 255, 0.42)";
+  const borderC = (tokens && tokens.border) || "rgba(15, 23, 42, 0.10)";
+  const settingsInputBg = inputBg.replace(/[\d.]+\)$/, "0.42)");
+  const settingsBorderC = borderC.replace(/[\d.]+\)$/, "0.10)");
+  const input = document.createElement("input");
+  input.type = type;
+  input.placeholder = placeholder;
+  setStyles(input, {
+    width: "100%",
+    border: `1px solid ${settingsBorderC}`,
+    borderRadius: "12px",
+    padding: "10px 12px",
+    outline: "none",
+    background: settingsInputBg,
+    color: fg,
+    fontSize: "13px"
+  });
+  return input;
 }
 
 function createSettingsTextarea(label, placeholder, tokens) {
@@ -1592,6 +1731,7 @@ function createThemePicker(tokens, currentTheme, onChange) {
 
 async function loadInlineSettings() {
   const stored = await chrome.storage.local.get([
+    AI_PROVIDER_STORAGE_KEY,
     "aiEndpoint",
     "aiApiKey",
     "aiModel",
@@ -1599,45 +1739,20 @@ async function loadInlineSettings() {
     "experimentalTitleRewriteEnabled"
   ]);
 
-  return {
-    endpoint: normalizeSettingsEndpoint(stored.aiEndpoint || "https://api.openai.com/v1/chat/completions"),
-    apiKey: stored.aiApiKey || "",
-    model: stored.aiModel || "gpt-4.1-mini",
-    preference: stored.aiPreference || "",
-    experimentalTitleRewriteEnabled: Boolean(stored.experimentalTitleRewriteEnabled)
-  };
+  return resolveAISettingsDraft(stored);
 }
 
 async function saveInlineSettings(settings) {
-  const endpoint = normalizeSettingsEndpoint(settings.endpoint);
+  const endpoint = normalizeAIEndpoint(settings.endpoint);
 
   await chrome.storage.local.set({
+    [AI_PROVIDER_STORAGE_KEY]: settings.providerId || detectAIProviderPreset(endpoint),
     aiEndpoint: endpoint,
     aiApiKey: String(settings.apiKey || "").trim(),
     aiModel: String(settings.model || "").trim(),
     aiPreference: String(settings.preference || "").trim(),
     experimentalTitleRewriteEnabled: Boolean(settings.experimentalTitleRewriteEnabled)
   });
-}
-
-function normalizeSettingsEndpoint(endpoint) {
-  const value = String(endpoint || "").trim();
-
-  if (!value) {
-    return "https://api.openai.com/v1/chat/completions";
-  }
-
-  try {
-    const url = new URL(value);
-
-    if (url.pathname === "/" || url.pathname === "" || url.pathname === "/v1" || url.pathname === "/v1/") {
-      url.pathname = "/v1/chat/completions";
-    }
-
-    return url.toString();
-  } catch (_error) {
-    return value;
-  }
 }
 
 function ensureSpinnerStyle() {

--- a/manifest.json
+++ b/manifest.json
@@ -30,6 +30,7 @@
         "<all_urls>"
       ],
       "js": [
+        "ai-provider-config.js",
         "content.js"
       ],
       "run_at": "document_idle"

--- a/options.html
+++ b/options.html
@@ -51,6 +51,11 @@
 
       <div class="settings-stack">
         <label class="field">
+          <span>服务商</span>
+          <select id="provider-select"></select>
+        </label>
+
+        <label class="field">
           <span>接口地址</span>
           <input id="endpoint-input" type="url" placeholder="https://api.openai.com/v1/chat/completions" />
         </label>
@@ -62,10 +67,13 @@
 
         <label class="field">
           <span>模型名</span>
-          <input id="model-input" type="text" placeholder="gpt-4.1-mini" />
+          <div class="field-control-stack">
+            <select id="model-select"></select>
+            <input id="model-input" class="hidden" type="text" placeholder="输入自定义模型名" />
+          </div>
         </label>
 
-        <div class="helper-inline">填到根路径或 `/v1` 也可以，插件会自动补全到 Chat Completions。</div>
+        <div class="helper-inline">切换服务商会带入推荐地址和模型，你仍可继续手改。地址填到基础版本路径也会自动补全到 Chat Completions。</div>
 
         <label class="field large-field">
           <span>整理偏好</span>
@@ -90,6 +98,7 @@
     </section>
   </main>
   <script src="theme.js"></script>
+  <script src="ai-provider-config.js"></script>
   <script src="options.js"></script>
 </body>
 

--- a/options.js
+++ b/options.js
@@ -1,5 +1,20 @@
+const {
+  AI_PROVIDER_STORAGE_KEY,
+  CUSTOM_AI_MODEL_OPTION_VALUE,
+  applyAIProviderPreset,
+  detectAIProviderPreset,
+  normalizeAIEndpoint,
+  populateAIModelSelect,
+  populateAIProviderSelect,
+  resolveAIModelSelection,
+  resolveAISettingsDraft,
+  updateAIKeyPlaceholder
+} = globalThis.AIProviderConfig;
+
+const providerSelect = document.getElementById("provider-select");
 const endpointInput = document.getElementById("endpoint-input");
 const apiKeyInput = document.getElementById("api-key-input");
+const modelSelect = document.getElementById("model-select");
 const modelInput = document.getElementById("model-input");
 const preferenceInput = document.getElementById("preference-input");
 const titleRewriteInput = document.getElementById("title-rewrite-input");
@@ -10,6 +25,9 @@ const modeToggle = document.getElementById("mode-toggle");
 const swatches = document.querySelectorAll(".theme-swatch");
 
 initialize();
+
+populateAIProviderSelect(providerSelect);
+populateAIModelSelect(modelSelect, providerSelect.value, "");
 
 swatches.forEach((swatch) => {
   swatch.addEventListener("click", async () => {
@@ -26,6 +44,40 @@ modeToggle.addEventListener("click", async () => {
   await chrome.storage.local.set({ themeMode: next });
   document.documentElement.dataset.themeMode = next;
   updateModeToggle(next);
+});
+
+providerSelect.addEventListener("change", () => {
+  const nextDraft = applyAIProviderPreset(providerSelect.value, {
+    endpoint: endpointInput.value,
+    apiKey: apiKeyInput.value,
+    model: getCurrentModelValue(),
+    preference: preferenceInput.value,
+    experimentalTitleRewriteEnabled: titleRewriteInput.checked
+  });
+
+  endpointInput.value = nextDraft.endpoint;
+  syncModelControls(nextDraft.providerId, nextDraft.model);
+  updateAIKeyPlaceholder(apiKeyInput, nextDraft.providerId);
+});
+
+endpointInput.addEventListener("input", () => {
+  providerSelect.value = detectAIProviderPreset(endpointInput.value);
+  syncModelControls(providerSelect.value, getCurrentModelValue());
+  updateAIKeyPlaceholder(apiKeyInput, providerSelect.value);
+});
+
+modelSelect.addEventListener("change", () => {
+  const isCustom = modelSelect.value === CUSTOM_AI_MODEL_OPTION_VALUE;
+
+  if (isCustom && !modelInput.value.trim()) {
+    modelInput.value = modelSelect.dataset.selectedPresetModel || "";
+  }
+
+  if (!isCustom) {
+    modelSelect.dataset.selectedPresetModel = modelSelect.value;
+  }
+
+  modelInput.classList.toggle("hidden", !isCustom);
 });
 
 function updateSwatchSelection(color) {
@@ -68,6 +120,7 @@ runButton.addEventListener("click", async () => {
 
 async function initialize() {
   const stored = await chrome.storage.local.get([
+    AI_PROVIDER_STORAGE_KEY,
     "aiEndpoint",
     "aiApiKey",
     "aiModel",
@@ -76,22 +129,27 @@ async function initialize() {
     "themeColor",
     "themeMode"
   ]);
-  endpointInput.value = normalizeEndpoint(stored.aiEndpoint || "https://api.openai.com/v1/chat/completions");
-  apiKeyInput.value = stored.aiApiKey || "";
-  modelInput.value = stored.aiModel || "gpt-4.1-mini";
-  preferenceInput.value = stored.aiPreference || "";
-  titleRewriteInput.checked = Boolean(stored.experimentalTitleRewriteEnabled);
+
+  const draft = resolveAISettingsDraft(stored);
+  providerSelect.value = draft.providerId;
+  endpointInput.value = draft.endpoint;
+  apiKeyInput.value = draft.apiKey;
+  syncModelControls(draft.providerId, draft.model);
+  preferenceInput.value = draft.preference;
+  titleRewriteInput.checked = draft.experimentalTitleRewriteEnabled;
+  updateAIKeyPlaceholder(apiKeyInput, draft.providerId);
   updateSwatchSelection(stored.themeColor || "neutral");
   updateModeToggle(stored.themeMode || "light");
 }
 
 async function saveSettings() {
-  const endpoint = normalizeEndpoint(endpointInput.value);
+  const endpoint = normalizeAIEndpoint(endpointInput.value);
 
   await chrome.storage.local.set({
+    [AI_PROVIDER_STORAGE_KEY]: providerSelect.value,
     aiEndpoint: endpoint,
     aiApiKey: apiKeyInput.value.trim(),
-    aiModel: modelInput.value.trim(),
+    aiModel: getCurrentModelValue(),
     aiPreference: preferenceInput.value.trim(),
     experimentalTitleRewriteEnabled: titleRewriteInput.checked
   });
@@ -99,28 +157,22 @@ async function saveSettings() {
   endpointInput.value = endpoint;
 }
 
+function syncModelControls(providerId, modelValue) {
+  const selection = resolveAIModelSelection(providerId, modelValue);
+  populateAIModelSelect(modelSelect, providerId, modelValue);
+  modelSelect.value = selection.selectedValue;
+  modelSelect.dataset.selectedPresetModel =
+    selection.selectedValue === CUSTOM_AI_MODEL_OPTION_VALUE ? selection.options[0]?.value || "" : selection.selectedValue;
+  modelInput.value = selection.customValue;
+  modelInput.classList.toggle("hidden", selection.selectedValue !== CUSTOM_AI_MODEL_OPTION_VALUE);
+}
+
+function getCurrentModelValue() {
+  return modelSelect.value === CUSTOM_AI_MODEL_OPTION_VALUE ? modelInput.value.trim() : modelSelect.value;
+}
+
 function setBusy(busy, message) {
   saveButton.disabled = busy;
   runButton.disabled = busy;
   statusText.textContent = message;
-}
-
-function normalizeEndpoint(endpoint) {
-  const value = String(endpoint || "").trim();
-
-  if (!value) {
-    return "https://api.openai.com/v1/chat/completions";
-  }
-
-  try {
-    const url = new URL(value);
-
-    if (url.pathname === "/" || url.pathname === "" || url.pathname === "/v1" || url.pathname === "/v1/") {
-      url.pathname = "/v1/chat/completions";
-    }
-
-    return url.toString();
-  } catch (_error) {
-    return value;
-  }
 }

--- a/popup.html
+++ b/popup.html
@@ -10,112 +10,26 @@
 
 <body class="popup-body">
   <main class="popup-shell">
-    <section id="popup-home" class="popup-page">
-      <section class="surface compact-surface">
-        <div class="section-title">快捷键</div>
-        <div class="shortcut-list">
-          <div class="shortcut-item">
-            <div class="shortcut-copy">整理标签页</div>
-            <kbd id="organize-shortcut" class="shortcut-key">⌘⇧J</kbd>
-          </div>
-          <div class="shortcut-item">
-            <div class="shortcut-copy">搜索标签页</div>
-            <kbd id="search-shortcut" class="shortcut-key">⌘⇧K</kbd>
-          </div>
+    <section class="surface compact-surface">
+      <div class="section-title">快捷键</div>
+      <div class="shortcut-list">
+        <div class="shortcut-item">
+          <div class="shortcut-copy">整理标签页</div>
+          <kbd id="organize-shortcut" class="shortcut-key">⌘⇧J</kbd>
         </div>
-      </section>
-
-      <section class="surface compact-surface">
-        <div class="button-stack popup-main-actions">
-          <button id="run-button" class="primary-button large-button">一键整理标签页</button>
-          <button id="search-button" class="secondary-button large-button">打开搜索框</button>
-          <button id="settings-button" class="secondary-button large-button">设置</button>
+        <div class="shortcut-item">
+          <div class="shortcut-copy">搜索标签页</div>
+          <kbd id="search-shortcut" class="shortcut-key">⌘⇧K</kbd>
         </div>
-      </section>
+      </div>
     </section>
 
-    <section id="popup-settings-view" class="popup-page hidden">
-      <section class="surface compact-surface">
-        <div class="section-head">
-          <div class="settings-page-title">设置</div>
-          <button id="settings-back-button" class="secondary-button">返回</button>
-        </div>
-
-        <div class="theme-section">
-          <div class="theme-colors">
-            <button class="theme-swatch" data-color="neutral" title="默认"></button>
-            <button class="theme-swatch" data-color="blue" title="蓝色"></button>
-            <button class="theme-swatch" data-color="green" title="绿色"></button>
-            <button class="theme-swatch" data-color="purple" title="紫色"></button>
-            <button class="theme-swatch" data-color="orange" title="橙色"></button>
-          </div>
-          <button id="mode-toggle" class="mode-toggle" data-mode="light" title="切换深浅色">
-            <span class="mode-toggle-track">
-              <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
-                stroke-linecap="round" stroke-linejoin="round">
-                <circle cx="12" cy="12" r="4" />
-                <path
-                  d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41" />
-              </svg>
-              <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
-                stroke-linecap="round" stroke-linejoin="round">
-                <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
-              </svg>
-            </span>
-            <span class="mode-toggle-thumb">
-              <svg class="thumb-sun" width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor"
-                stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
-                <circle cx="12" cy="12" r="4" />
-                <path
-                  d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41" />
-              </svg>
-              <svg class="thumb-moon" width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor"
-                stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
-                <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
-              </svg>
-            </span>
-          </button>
-        </div>
-
-        <div class="settings-stack">
-          <label class="field">
-            <span>接口地址</span>
-            <input id="endpoint-input" type="url" placeholder="https://api.openai.com/v1/chat/completions" />
-          </label>
-
-          <label class="field">
-            <span>API Key</span>
-            <input id="api-key-input" type="password" placeholder="sk-..." />
-          </label>
-
-          <label class="field">
-            <span>模型名</span>
-            <input id="model-input" type="text" placeholder="gpt-4.1-mini" />
-          </label>
-
-          <div class="helper-inline">填到根路径或 `/v1` 也可以，插件会自动补全到 Chat Completions。</div>
-
-          <label class="field large-field">
-            <span>整理偏好</span>
-            <textarea id="preference-input" rows="5" placeholder="例如：工作相关靠前，阅读类折叠，娱乐类靠后。"></textarea>
-          </label>
-
-          <label class="toggle-field">
-            <input id="title-rewrite-input" type="checkbox" />
-            <span>
-              <strong>实验功能：整理后简化网页标题</strong>
-              <small>AI 重排完成后，尝试为可注入网页写入更短的临时标题。刷新页面或网站自行改标题后可能失效。</small>
-            </span>
-          </label>
-
-          <div class="button-row minimal-actions">
-            <button id="save-button" class="primary-button">保存设置</button>
-            <button id="save-run-button" class="secondary-button">保存并立即整理</button>
-          </div>
-
-          <div id="settings-status-text" class="helper-text"></div>
-        </div>
-      </section>
+    <section class="surface compact-surface">
+      <div class="button-stack popup-main-actions">
+        <button id="run-button" class="primary-button large-button">一键整理标签页</button>
+        <button id="search-button" class="secondary-button large-button">打开搜索框</button>
+        <button id="settings-button" class="secondary-button large-button">设置</button>
+      </div>
     </section>
   </main>
   <script src="theme.js"></script>

--- a/popup.js
+++ b/popup.js
@@ -3,20 +3,6 @@ const searchButton = document.getElementById("search-button");
 const settingsButton = document.getElementById("settings-button");
 const organizeShortcut = document.getElementById("organize-shortcut");
 const searchShortcut = document.getElementById("search-shortcut");
-const popupHome = document.getElementById("popup-home");
-const popupSettingsView = document.getElementById("popup-settings-view");
-
-const settingsBackButton = document.getElementById("settings-back-button");
-const modeToggle = document.getElementById("mode-toggle");
-const swatches = document.querySelectorAll(".theme-swatch");
-const endpointInput = document.getElementById("endpoint-input");
-const apiKeyInput = document.getElementById("api-key-input");
-const modelInput = document.getElementById("model-input");
-const preferenceInput = document.getElementById("preference-input");
-const titleRewriteInput = document.getElementById("title-rewrite-input");
-const saveButton = document.getElementById("save-button");
-const saveRunButton = document.getElementById("save-run-button");
-const settingsStatusText = document.getElementById("settings-status-text");
 
 let pollTimer = null;
 
@@ -44,69 +30,8 @@ searchButton.addEventListener("click", async () => {
 });
 
 settingsButton.addEventListener("click", async () => {
-  showPage("settings");
-  await loadSettingsIntoForm();
-});
-
-swatches.forEach((swatch) => {
-  swatch.addEventListener("click", async () => {
-    const color = swatch.dataset.color;
-    await chrome.storage.local.set({ themeColor: color });
-    document.documentElement.dataset.themeColor = color;
-    updateSwatchSelection(color);
-  });
-});
-
-modeToggle.addEventListener("click", async () => {
-  const current = document.documentElement.dataset.themeMode || "light";
-  const next = current === "light" ? "dark" : "light";
-  await chrome.storage.local.set({ themeMode: next });
-  document.documentElement.dataset.themeMode = next;
-  updateModeToggle(next);
-});
-
-function updateSwatchSelection(color) {
-  swatches.forEach((s) => {
-    s.setAttribute("aria-pressed", s.dataset.color === color ? "true" : "false");
-  });
-}
-
-function updateModeToggle(mode) {
-  modeToggle.dataset.mode = mode;
-}
-
-settingsBackButton.addEventListener("click", () => {
-  showPage("home");
-});
-
-saveButton.addEventListener("click", async () => {
-  setSettingsBusy(true, "正在保存…");
-
-  try {
-    await saveSettings();
-    setSettingsBusy(false, "已保存");
-  } catch (error) {
-    setSettingsBusy(false, error instanceof Error ? error.message : "保存失败");
-  }
-});
-
-saveRunButton.addEventListener("click", async () => {
-  setSettingsBusy(true, "保存并开始整理…");
-
-  try {
-    await saveSettings();
-    const response = await chrome.runtime.sendMessage({ type: "run-ai-organization" });
-
-    if (!response?.ok && !response?.skipped) {
-      throw new Error(response?.error || "整理失败");
-    }
-
-    setSettingsBusy(false, response?.summary || response?.reason || "已开始");
-    showPage("home");
-    setRunBusy(true);
-  } catch (error) {
-    setSettingsBusy(false, error instanceof Error ? error.message : "整理失败");
-  }
+  await chrome.runtime.openOptionsPage();
+  window.close();
 });
 
 async function initialize() {
@@ -131,11 +56,6 @@ async function refreshState() {
   setRunBusy(Boolean(response.state.busy));
 }
 
-function showPage(page) {
-  popupHome.classList.toggle("hidden", page !== "home");
-  popupSettingsView.classList.toggle("hidden", page !== "settings");
-}
-
 function setRunBusy(busy) {
   runButton.disabled = busy;
   runButton.textContent = busy ? "整理中…" : "一键整理标签页";
@@ -153,67 +73,6 @@ async function renderShortcuts() {
   } catch (_error) {
     organizeShortcut.textContent = "⌘⇧J";
     searchShortcut.textContent = "⌘⇧K";
-  }
-}
-
-async function loadSettingsIntoForm() {
-  const stored = await chrome.storage.local.get([
-    "aiEndpoint",
-    "aiApiKey",
-    "aiModel",
-    "aiPreference",
-    "experimentalTitleRewriteEnabled",
-    "themeColor",
-    "themeMode"
-  ]);
-
-  endpointInput.value = normalizeEndpoint(stored.aiEndpoint || "https://api.openai.com/v1/chat/completions");
-  apiKeyInput.value = stored.aiApiKey || "";
-  modelInput.value = stored.aiModel || "gpt-4.1-mini";
-  preferenceInput.value = stored.aiPreference || "";
-  titleRewriteInput.checked = Boolean(stored.experimentalTitleRewriteEnabled);
-  settingsStatusText.textContent = "";
-  updateSwatchSelection(stored.themeColor || "neutral");
-  updateModeToggle(stored.themeMode || "light");
-}
-
-async function saveSettings() {
-  const endpoint = normalizeEndpoint(endpointInput.value);
-
-  await chrome.storage.local.set({
-    aiEndpoint: endpoint,
-    aiApiKey: apiKeyInput.value.trim(),
-    aiModel: modelInput.value.trim(),
-    aiPreference: preferenceInput.value.trim(),
-    experimentalTitleRewriteEnabled: titleRewriteInput.checked
-  });
-
-  endpointInput.value = endpoint;
-}
-
-function setSettingsBusy(busy, message) {
-  saveButton.disabled = busy;
-  saveRunButton.disabled = busy;
-  settingsStatusText.textContent = message;
-}
-
-function normalizeEndpoint(endpoint) {
-  const value = String(endpoint || "").trim();
-
-  if (!value) {
-    return "https://api.openai.com/v1/chat/completions";
-  }
-
-  try {
-    const url = new URL(value);
-
-    if (url.pathname === "/" || url.pathname === "" || url.pathname === "/v1" || url.pathname === "/v1/") {
-      url.pathname = "/v1/chat/completions";
-    }
-
-    return url.toString();
-  } catch (_error) {
-    return value;
   }
 }
 

--- a/search.html
+++ b/search.html
@@ -18,6 +18,7 @@
     </section>
   </main>
   <script src="theme.js"></script>
+  <script src="ai-provider-config.js"></script>
   <script src="search.js"></script>
 </body>
 

--- a/search.js
+++ b/search.js
@@ -1,3 +1,16 @@
+const {
+  AI_PROVIDER_STORAGE_KEY,
+  CUSTOM_AI_MODEL_OPTION_VALUE,
+  applyAIProviderPreset,
+  detectAIProviderPreset,
+  normalizeAIEndpoint,
+  populateAIModelSelect,
+  populateAIProviderSelect,
+  resolveAIModelSelection,
+  resolveAISettingsDraft,
+  updateAIKeyPlaceholder
+} = globalThis.AIProviderConfig;
+
 const ACTIONS = ["open", "close", "bookmark_close"];
 const NATURAL_BATCH_ACTIONS = [
   { action: "bookmark_close", label: "关闭并加入收藏" },
@@ -458,7 +471,7 @@ async function initialize() {
     });
 
     const helper = document.createElement("div");
-    helper.textContent = "设置主题色、AI接口和整理偏好";
+    helper.textContent = "设置主题色、服务商、AI 接口和整理偏好，切换服务商会带入推荐地址和模型。";
     setStyles(helper, {
       padding: "0 10px",
       fontSize: "12px",
@@ -473,11 +486,15 @@ async function initialize() {
       minHeight: "18px"
     });
 
-    const fields = [
-      createSettingsField("接口地址", "url", "https://api.openai.com/v1/chat/completions"),
-      createSettingsField("API Key", "password", "sk-..."),
-      createSettingsField("模型名", "text", "gpt-4.1-mini")
-    ];
+    const providerField = createSettingsSelect("服务商");
+    populateAIProviderSelect(providerField.input);
+
+    const endpointField = createSettingsField("接口地址", "url", "https://api.openai.com/v1/chat/completions");
+    const apiKeyField = createSettingsField("API Key", "password", "sk-...");
+    const modelField = createSettingsSelect("模型名");
+    const customModelInput = createSettingsStandaloneInput("text", "输入自定义模型名");
+    customModelInput.style.display = "none";
+    modelField.wrapper.appendChild(customModelInput);
     const preferenceField = createSettingsTextarea("整理偏好", "例如：工作相关靠前，阅读类折叠，娱乐类靠后。");
     const toggleField = createSettingsToggle("实验功能：整理后简化网页标题", "整理后尝试为可注入网页写入更短的临时标题。");
 
@@ -492,9 +509,10 @@ async function initialize() {
     const saveButton = createToolbarButton("保存设置", async () => {
       status.textContent = "正在保存…";
       await saveInlineSettings({
-        endpoint: fields[0].input.value,
-        apiKey: fields[1].input.value,
-        model: fields[2].input.value,
+        providerId: providerField.input.value,
+        endpoint: endpointField.input.value,
+        apiKey: apiKeyField.input.value,
+        model: getCurrentModelValue(),
         preference: preferenceField.input.value,
         experimentalTitleRewriteEnabled: toggleField.input.checked
       });
@@ -504,9 +522,10 @@ async function initialize() {
     const runButton = createToolbarButton("保存并立即整理标签页", async () => {
       status.textContent = "保存并开始整理…";
       await saveInlineSettings({
-        endpoint: fields[0].input.value,
-        apiKey: fields[1].input.value,
-        model: fields[2].input.value,
+        providerId: providerField.input.value,
+        endpoint: endpointField.input.value,
+        apiKey: apiKeyField.input.value,
+        model: getCurrentModelValue(),
         preference: preferenceField.input.value,
         experimentalTitleRewriteEnabled: toggleField.input.checked
       });
@@ -522,24 +541,77 @@ async function initialize() {
 
     shell.appendChild(title);
     shell.appendChild(helper);
-    fields.forEach((field) => shell.appendChild(field.wrapper));
+    shell.appendChild(providerField.wrapper);
+    shell.appendChild(endpointField.wrapper);
+    shell.appendChild(apiKeyField.wrapper);
+    shell.appendChild(modelField.wrapper);
     shell.appendChild(preferenceField.wrapper);
     shell.appendChild(toggleField.wrapper);
     shell.appendChild(actionRow);
     shell.appendChild(status);
     list.appendChild(shell);
 
+    providerField.input.addEventListener("change", () => {
+      const nextDraft = applyAIProviderPreset(providerField.input.value, {
+        endpoint: endpointField.input.value,
+        apiKey: apiKeyField.input.value,
+        model: getCurrentModelValue(),
+        preference: preferenceField.input.value,
+        experimentalTitleRewriteEnabled: toggleField.input.checked
+      });
+
+      endpointField.input.value = nextDraft.endpoint;
+      syncModelControls(nextDraft.providerId, nextDraft.model);
+      updateAIKeyPlaceholder(apiKeyField.input, nextDraft.providerId);
+    });
+
+    endpointField.input.addEventListener("input", () => {
+      providerField.input.value = detectAIProviderPreset(endpointField.input.value);
+      syncModelControls(providerField.input.value, getCurrentModelValue());
+      updateAIKeyPlaceholder(apiKeyField.input, providerField.input.value);
+    });
+
+    modelField.input.addEventListener("change", () => {
+      const isCustom = modelField.input.value === CUSTOM_AI_MODEL_OPTION_VALUE;
+
+      if (isCustom && !customModelInput.value.trim()) {
+        customModelInput.value = modelField.input.dataset.selectedPresetModel || "";
+      }
+
+      if (!isCustom) {
+        modelField.input.dataset.selectedPresetModel = modelField.input.value;
+      }
+
+      customModelInput.style.display = isCustom ? "block" : "none";
+    });
+
     loadInlineSettings()
       .then((settings) => {
-        fields[0].input.value = settings.endpoint;
-        fields[1].input.value = settings.apiKey;
-        fields[2].input.value = settings.model;
+        providerField.input.value = settings.providerId;
+        endpointField.input.value = settings.endpoint;
+        apiKeyField.input.value = settings.apiKey;
+        syncModelControls(settings.providerId, settings.model);
         preferenceField.input.value = settings.preference;
         toggleField.input.checked = settings.experimentalTitleRewriteEnabled;
+        updateAIKeyPlaceholder(apiKeyField.input, settings.providerId);
       })
       .catch((error) => {
         status.textContent = error instanceof Error ? error.message : "读取设置失败";
       });
+
+    function syncModelControls(providerId, modelValue) {
+      const selection = resolveAIModelSelection(providerId, modelValue);
+      populateAIModelSelect(modelField.input, providerId, modelValue);
+      modelField.input.value = selection.selectedValue;
+      modelField.input.dataset.selectedPresetModel =
+        selection.selectedValue === CUSTOM_AI_MODEL_OPTION_VALUE ? selection.options[0]?.value || "" : selection.selectedValue;
+      customModelInput.value = selection.customValue;
+      customModelInput.style.display = selection.selectedValue === CUSTOM_AI_MODEL_OPTION_VALUE ? "block" : "none";
+    }
+
+    function getCurrentModelValue() {
+      return modelField.input.value === CUSTOM_AI_MODEL_OPTION_VALUE ? customModelInput.value.trim() : modelField.input.value;
+    }
   }
 
   function createRow(entry, index) {
@@ -1012,7 +1084,7 @@ function buildEntries(tabs, query) {
       kind: "command",
       command: "settings",
       title: "设置",
-      subtitle: "设置主题色、AI接口和整理偏好"
+      subtitle: "设置主题色、服务商、AI 接口和整理偏好"
     });
   }
 
@@ -1164,6 +1236,45 @@ function createSettingsField(label, type, placeholder) {
     border: "1px solid rgba(15, 23, 42, 0.12)",
     borderRadius: "12px",
     padding: "10px 12px",
+    paddingRight: "40px",
+    outline: "none",
+    background: "#ffffff",
+    appearance: "none",
+    WebkitAppearance: "none",
+    backgroundImage:
+      "url(\"data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12' fill='none'%3E%3Cpath d='M2 4.5L6 8L10 4.5' stroke='%236d6d67' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E\")",
+    backgroundRepeat: "no-repeat",
+    backgroundPosition: "right 14px center",
+    backgroundSize: "12px 12px",
+    color: "#0f172a",
+    fontSize: "13px"
+  });
+
+  wrapper.appendChild(text);
+  wrapper.appendChild(input);
+  return { wrapper, input };
+}
+
+function createSettingsSelect(label) {
+  const wrapper = document.createElement("label");
+  setStyles(wrapper, {
+    display: "flex",
+    flexDirection: "column",
+    gap: "6px",
+    padding: "0 10px",
+    fontSize: "12px",
+    color: "#0f172a"
+  });
+
+  const text = document.createElement("span");
+  text.textContent = label;
+
+  const input = document.createElement("select");
+  setStyles(input, {
+    width: "100%",
+    border: "1px solid rgba(15, 23, 42, 0.12)",
+    borderRadius: "12px",
+    padding: "10px 12px",
     outline: "none",
     background: "#ffffff",
     color: "#0f172a",
@@ -1173,6 +1284,23 @@ function createSettingsField(label, type, placeholder) {
   wrapper.appendChild(text);
   wrapper.appendChild(input);
   return { wrapper, input };
+}
+
+function createSettingsStandaloneInput(type, placeholder) {
+  const input = document.createElement("input");
+  input.type = type;
+  input.placeholder = placeholder;
+  setStyles(input, {
+    width: "100%",
+    border: "1px solid rgba(15, 23, 42, 0.12)",
+    borderRadius: "12px",
+    padding: "10px 12px",
+    outline: "none",
+    background: "#ffffff",
+    color: "#0f172a",
+    fontSize: "13px"
+  });
+  return input;
 }
 
 function createSettingsTextarea(label, placeholder) {
@@ -1256,6 +1384,7 @@ function createSettingsToggle(label, helper) {
 
 async function loadInlineSettings() {
   const stored = await chrome.storage.local.get([
+    AI_PROVIDER_STORAGE_KEY,
     "aiEndpoint",
     "aiApiKey",
     "aiModel",
@@ -1263,45 +1392,20 @@ async function loadInlineSettings() {
     "experimentalTitleRewriteEnabled"
   ]);
 
-  return {
-    endpoint: normalizeSettingsEndpoint(stored.aiEndpoint || "https://api.openai.com/v1/chat/completions"),
-    apiKey: stored.aiApiKey || "",
-    model: stored.aiModel || "gpt-4.1-mini",
-    preference: stored.aiPreference || "",
-    experimentalTitleRewriteEnabled: Boolean(stored.experimentalTitleRewriteEnabled)
-  };
+  return resolveAISettingsDraft(stored);
 }
 
 async function saveInlineSettings(settings) {
-  const endpoint = normalizeSettingsEndpoint(settings.endpoint);
+  const endpoint = normalizeAIEndpoint(settings.endpoint);
 
   await chrome.storage.local.set({
+    [AI_PROVIDER_STORAGE_KEY]: settings.providerId || detectAIProviderPreset(endpoint),
     aiEndpoint: endpoint,
     aiApiKey: String(settings.apiKey || "").trim(),
     aiModel: String(settings.model || "").trim(),
     aiPreference: String(settings.preference || "").trim(),
     experimentalTitleRewriteEnabled: Boolean(settings.experimentalTitleRewriteEnabled)
   });
-}
-
-function normalizeSettingsEndpoint(endpoint) {
-  const value = String(endpoint || "").trim();
-
-  if (!value) {
-    return "https://api.openai.com/v1/chat/completions";
-  }
-
-  try {
-    const url = new URL(value);
-
-    if (url.pathname === "/" || url.pathname === "" || url.pathname === "/v1" || url.pathname === "/v1/") {
-      url.pathname = "/v1/chat/completions";
-    }
-
-    return url.toString();
-  } catch (_error) {
-    return value;
-  }
 }
 
 function ensureSpinnerStyle() {

--- a/tests/ai-provider-config.test.mjs
+++ b/tests/ai-provider-config.test.mjs
@@ -1,0 +1,128 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import config from "../ai-provider-config.js";
+
+const {
+  AI_PROVIDER_STORAGE_KEY,
+  AI_PROVIDER_PRESETS,
+  CUSTOM_AI_MODEL_OPTION_VALUE,
+  CUSTOM_AI_PROVIDER_ID,
+  DEFAULT_AI_ENDPOINT,
+  DEFAULT_AI_MODEL,
+  applyAIProviderPreset,
+  detectAIProviderPreset,
+  getAIModelOptions,
+  normalizeAIEndpoint,
+  resolveAIModelSelection,
+  resolveAISettingsDraft
+} = config;
+
+test("exports the expected preset ids", () => {
+  assert.deepEqual(
+    AI_PROVIDER_PRESETS.map((item) => item.id),
+    ["openai", "openrouter", "groq", "deepseek", "siliconflow", "dashscope", "custom"]
+  );
+});
+
+test("normalizes root and versioned compatible endpoints", () => {
+  assert.equal(normalizeAIEndpoint("https://api.openai.com"), "https://api.openai.com/v1/chat/completions");
+  assert.equal(
+    normalizeAIEndpoint("https://openrouter.ai/api/v1"),
+    "https://openrouter.ai/api/v1/chat/completions"
+  );
+  assert.equal(
+    normalizeAIEndpoint("https://dashscope.aliyuncs.com/compatible-mode/v1/"),
+    "https://dashscope.aliyuncs.com/compatible-mode/v1/chat/completions"
+  );
+  assert.equal(
+    normalizeAIEndpoint("https://api.groq.com/openai/v1/chat/completions"),
+    "https://api.groq.com/openai/v1/chat/completions"
+  );
+});
+
+test("detects provider presets from normalized endpoints", () => {
+  assert.equal(detectAIProviderPreset("https://api.openai.com/v1/chat/completions"), "openai");
+  assert.equal(detectAIProviderPreset("https://openrouter.ai/api/v1"), "openrouter");
+  assert.equal(detectAIProviderPreset("https://api.groq.com/openai/v1/chat/completions"), "groq");
+  assert.equal(detectAIProviderPreset("https://api.deepseek.com/v1"), "deepseek");
+  assert.equal(detectAIProviderPreset("https://api.siliconflow.cn/v1/chat/completions"), "siliconflow");
+  assert.equal(detectAIProviderPreset("https://dashscope.aliyuncs.com/compatible-mode/v1"), "dashscope");
+  assert.equal(detectAIProviderPreset("https://example.com/custom/v1"), "custom");
+});
+
+test("applies provider presets with recommended endpoint, model, and API key placeholder", () => {
+  const preset = applyAIProviderPreset("groq", { apiKey: "secret", preference: "work first" });
+  assert.equal(preset.providerId, "groq");
+  assert.equal(preset.endpoint, "https://api.groq.com/openai/v1/chat/completions");
+  assert.equal(preset.model, "llama-3.3-70b-versatile");
+  assert.equal(preset.apiKey, "secret");
+  assert.equal(preset.preference, "work first");
+  assert.equal(preset.apiKeyPlaceholder, "填写 Groq API Key");
+});
+
+test("returns common model options for a provider", () => {
+  const values = getAIModelOptions("openai").map((item) => item.value);
+
+  assert.deepEqual(values, ["gpt-4.1-mini", "gpt-4.1", "gpt-4.1-nano", "gpt-4o-mini", "gpt-4o"]);
+});
+
+test("keeps known models selected in the model preset dropdown", () => {
+  const selection = resolveAIModelSelection("deepseek", "deepseek-reasoner");
+
+  assert.equal(selection.selectedValue, "deepseek-reasoner");
+  assert.equal(selection.customValue, "");
+});
+
+test("switches to custom model mode when model is not in the preset list", () => {
+  const selection = resolveAIModelSelection("openrouter", "my-special-model");
+
+  assert.equal(selection.selectedValue, CUSTOM_AI_MODEL_OPTION_VALUE);
+  assert.equal(selection.customValue, "my-special-model");
+});
+
+test("custom provider uses custom model mode directly", () => {
+  const selection = resolveAIModelSelection(CUSTOM_AI_PROVIDER_ID, "anything-model");
+
+  assert.equal(selection.selectedValue, CUSTOM_AI_MODEL_OPTION_VALUE);
+  assert.equal(selection.customValue, "anything-model");
+});
+
+test("resolves stored settings using saved provider id when available", () => {
+  const draft = resolveAISettingsDraft({
+    [AI_PROVIDER_STORAGE_KEY]: "openrouter",
+    aiEndpoint: "https://openrouter.ai/api/v1",
+    aiApiKey: "sk-or-v1-test",
+    aiModel: "",
+    aiPreference: "group by task",
+    experimentalTitleRewriteEnabled: true
+  });
+
+  assert.equal(draft.providerId, "openrouter");
+  assert.equal(draft.endpoint, "https://openrouter.ai/api/v1/chat/completions");
+  assert.equal(draft.apiKey, "sk-or-v1-test");
+  assert.equal(draft.apiKeyPlaceholder, "填写 OpenRouter API Key");
+  assert.equal(draft.model, "openai/gpt-4.1-mini");
+  assert.equal(draft.preference, "group by task");
+  assert.equal(draft.experimentalTitleRewriteEnabled, true);
+});
+
+test("falls back to defaults for blank settings", () => {
+  const draft = resolveAISettingsDraft({});
+
+  assert.equal(draft.providerId, "openai");
+  assert.equal(draft.endpoint, DEFAULT_AI_ENDPOINT);
+  assert.equal(draft.model, DEFAULT_AI_MODEL);
+});
+
+test("keeps custom provider selection when endpoint does not match a preset", () => {
+  const draft = resolveAISettingsDraft({
+    [AI_PROVIDER_STORAGE_KEY]: CUSTOM_AI_PROVIDER_ID,
+    aiEndpoint: "https://example.com/custom/v1",
+    aiModel: "my-model"
+  });
+
+  assert.equal(draft.providerId, CUSTOM_AI_PROVIDER_ID);
+  assert.equal(draft.endpoint, "https://example.com/custom/v1/chat/completions");
+  assert.equal(draft.model, "my-model");
+  assert.equal(draft.apiKeyPlaceholder, "填写兼容 OpenAI 的 API Key");
+});

--- a/ui.css
+++ b/ui.css
@@ -378,6 +378,7 @@ h1 {
 
 button,
 input,
+select,
 textarea {
   font: inherit;
 }
@@ -449,7 +450,14 @@ textarea {
   font-weight: 600;
 }
 
+.field-control-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
 .field input,
+.field select,
 .field textarea {
   width: 100%;
   padding: 13px 14px;
@@ -460,7 +468,18 @@ textarea {
   outline: none;
 }
 
+.field select {
+  appearance: none;
+  -webkit-appearance: none;
+  padding-right: 42px;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12' fill='none'%3E%3Cpath d='M2 4.5L6 8L10 4.5' stroke='%236d6d67' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 16px center;
+  background-size: 12px 12px;
+}
+
 .field input:focus,
+.field select:focus,
 .field textarea:focus {
   border-color: var(--border-focus);
 }


### PR DESCRIPTION
## 概要
- 为 AI 设置增加共享的 provider 预置、常见模型下拉和自定义模型输入
- 统一独立设置页为唯一设置入口，弹窗设置按钮直接跳转到 options 页面
- 同步搜索窗口和页内搜索面板的内联设置逻辑，并补充共享配置测试

## 测试
- node --test tests/ai-provider-config.test.mjs
- node --check ai-provider-config.js
- node --check background.js
- node --check options.js
- node --check popup.js
- node --check search.js
- node --check content.js