### PR TITLE
修复设置页快捷键搜索错误打开独立窗口的问题

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,10 +1,69 @@
+import "./tab-search-debug.js";
+import "./tab-search-routing.js";
+
 const DEFAULT_AI_ENDPOINT = "https://api.openai.com/v1/chat/completions";
 const DEFAULT_AI_MODEL = "gpt-4.1-mini";
 const TAB_GROUP_COLORS = ["grey", "blue", "red", "yellow", "green", "pink", "purple", "cyan", "orange"];
 const SEARCH_PANEL_BLOCKED_PROTOCOLS = ["about:", "brave:", "chrome:", "edge:", "vivaldi:"];
 const TITLE_REWRITE_MAX_LENGTH = 24;
+const {
+  EXTENSION_PAGE_SEARCH_CHANNEL_NAME,
+  EXTENSION_PAGE_SEARCH_REQUEST_STORAGE_KEY,
+  EXTENSION_PAGE_SEARCH_RESPONSE_STORAGE_KEY,
+  OPTIONS_PAGE_SEARCH_HASH_PREFIX,
+  OPTIONS_PAGE_SEARCH_HASH_RESPONSE_STORAGE_KEY,
+  EXTENSION_PAGE_PORT_NAME,
+  TAB_SEARCH_DELIVERY,
+  buildStandaloneSearchUrl,
+  isExtensionPageSearchResponseMatch,
+  isOptionsPagePortName,
+  resolveOptionsPageConnectionTabId,
+  resolveTabSearchDelivery,
+  shouldBackgroundHandleRuntimeMessage
+} = globalThis.TabSearchRouting;
+const { recordTabSearchDebug } = globalThis.TabSearchDebug;
 
 let organizationState = createIdleState();
+let standaloneSearchWindowId = null;
+let extensionPageRequestId = 0;
+
+const extensionPagePorts = new Map();
+const extensionPageUnboundPorts = new Set();
+const extensionPageChannel = typeof BroadcastChannel === "function"
+  ? new BroadcastChannel(EXTENSION_PAGE_SEARCH_CHANNEL_NAME)
+  : null;
+const pendingExtensionPageChannelRequests = new Map();
+const pendingExtensionPageRequests = new Map();
+const pendingExtensionPageHashRequests = new Map();
+const pendingExtensionPageStorageRequests = new Map();
+
+if (extensionPageChannel) {
+  extensionPageChannel.addEventListener("message", (event) => {
+    const message = event?.data;
+
+    if (message?.type !== "open-extension-tab-search-result") {
+      return;
+    }
+
+    const pending = pendingExtensionPageChannelRequests.get(message.requestId);
+
+    if (!pending) {
+      return;
+    }
+
+    pendingExtensionPageChannelRequests.delete(message.requestId);
+    clearTimeout(pending.timerId);
+    pending.resolve({
+      ok: Boolean(message.ok),
+      error: message.error || (message.ok ? "" : "options-channel-rejected")
+    });
+    void recordTabSearchDebug("background", "search.extension-overlay.channel.result", {
+      requestId: message.requestId,
+      ok: Boolean(message.ok),
+      error: message.error || ""
+    });
+  });
+}
 
 chrome.runtime.onInstalled.addListener((details) => {
   if (details.reason === "install") {
@@ -14,9 +73,12 @@ chrome.runtime.onInstalled.addListener((details) => {
 
 chrome.commands.onCommand.addListener(async (command) => {
   if (command === "search-tabs") {
+    await recordTabSearchDebug("background", "command.search-tabs", { command });
+
     try {
       await openTabSearch();
     } catch (error) {
+      await recordTabSearchDebug("background", "command.search-tabs.error", error);
       console.error("Search command failed:", error);
     }
 
@@ -33,6 +95,10 @@ chrome.commands.onCommand.addListener(async (command) => {
 });
 
 chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
+  if (!shouldBackgroundHandleRuntimeMessage(message)) {
+    return undefined;
+  }
+
   handleRuntimeMessage(message)
     .then((result) => sendResponse(result))
     .catch((error) => {
@@ -41,6 +107,140 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
     });
 
   return true;
+});
+
+chrome.storage.onChanged.addListener((changes, areaName) => {
+  if (areaName !== "local") {
+    return;
+  }
+
+  const response = changes[EXTENSION_PAGE_SEARCH_RESPONSE_STORAGE_KEY]?.newValue;
+  const hashResponse = changes[OPTIONS_PAGE_SEARCH_HASH_RESPONSE_STORAGE_KEY]?.newValue;
+
+  if (hashResponse?.requestId) {
+    const pendingHash = pendingExtensionPageHashRequests.get(hashResponse.requestId);
+
+    if (pendingHash) {
+      pendingExtensionPageHashRequests.delete(hashResponse.requestId);
+      clearTimeout(pendingHash.timerId);
+      pendingHash.resolve({
+        ok: Boolean(hashResponse.ok),
+        error: hashResponse.error || (hashResponse.ok ? "" : "options-hash-rejected")
+      });
+    }
+  }
+
+  if (!response?.requestId) {
+    return;
+  }
+
+  const pending = pendingExtensionPageStorageRequests.get(response.requestId);
+
+  if (!pending || !isExtensionPageSearchResponseMatch(response, response.requestId)) {
+    return;
+  }
+
+  pendingExtensionPageStorageRequests.delete(response.requestId);
+  clearTimeout(pending.timerId);
+  pending.resolve({
+    ok: Boolean(response.ok),
+    error: response.error || (response.ok ? "" : "options-storage-rejected")
+  });
+});
+
+chrome.runtime.onConnect.addListener((port) => {
+  if (!isOptionsPagePortName(port.name)) {
+    return;
+  }
+
+  let connectedTabId = resolveOptionsPageConnectionTabId({
+    senderTabId: port.sender?.tab?.id,
+    registeredTabId: null
+  });
+
+  if (connectedTabId) {
+    extensionPagePorts.set(connectedTabId, port);
+    void recordTabSearchDebug("background", "options-port.connected", {
+      tabId: connectedTabId,
+      source: "sender"
+    });
+  } else {
+    extensionPageUnboundPorts.add(port);
+    void recordTabSearchDebug("background", "options-port.connected", {
+      tabId: null,
+      source: "unbound"
+    });
+  }
+
+  port.onMessage.addListener((message) => {
+    if (message?.type === "register-options-page") {
+      const nextTabId = resolveOptionsPageConnectionTabId({
+        senderTabId: port.sender?.tab?.id,
+        registeredTabId: message.tabId
+      });
+
+      if (!nextTabId) {
+        extensionPageUnboundPorts.add(port);
+        void recordTabSearchDebug("background", "options-port.registered", {
+          tabId: null,
+          source: "unbound"
+        });
+        return;
+      }
+
+      if (connectedTabId && connectedTabId !== nextTabId && extensionPagePorts.get(connectedTabId) === port) {
+        extensionPagePorts.delete(connectedTabId);
+      }
+
+      extensionPageUnboundPorts.delete(port);
+      connectedTabId = nextTabId;
+      extensionPagePorts.set(connectedTabId, port);
+      void recordTabSearchDebug("background", "options-port.registered", {
+        tabId: connectedTabId,
+        source: port.sender?.tab?.id ? "sender" : "message"
+      });
+      return;
+    }
+
+    if (message?.type === "open-extension-tab-search-result") {
+      const pending = pendingExtensionPageRequests.get(message.requestId);
+
+      if (!pending) {
+        return;
+      }
+
+      pendingExtensionPageRequests.delete(message.requestId);
+      clearTimeout(pending.timerId);
+      pending.resolve({
+        ok: Boolean(message.ok),
+        error: message.error || (message.ok ? "" : "options-page-rejected")
+      });
+      void recordTabSearchDebug("background", "options-port.response", {
+        requestId: message.requestId,
+        ok: Boolean(message.ok),
+        error: message.error || ""
+      });
+    }
+  });
+
+  port.onDisconnect.addListener(() => {
+    if (connectedTabId && extensionPagePorts.get(connectedTabId) === port) {
+      extensionPagePorts.delete(connectedTabId);
+      void recordTabSearchDebug("background", "options-port.disconnected", { tabId: connectedTabId });
+    }
+
+    extensionPageUnboundPorts.delete(port);
+
+    for (const [requestId, pending] of pendingExtensionPageRequests.entries()) {
+      if (pending.port !== port) {
+        continue;
+      }
+
+      pendingExtensionPageRequests.delete(requestId);
+      clearTimeout(pending.timerId);
+      pending.resolve({ ok: false, error: "options-port-disconnected" });
+    }
+  });
 });
 
 async function handleRuntimeMessage(message) {
@@ -84,40 +284,401 @@ async function openTabSearch() {
     getSearchableTabs()
   ]);
 
-  if (!tab?.id) {
-    await openStandaloneSearchWindow();
-    return;
-  }
+  const delivery = resolveTabSearchDelivery({
+    url: tab?.url,
+    blockedProtocols: SEARCH_PANEL_BLOCKED_PROTOCOLS,
+    optionsPageUrl: chrome.runtime.getURL("options.html")
+  });
 
-  if (isSearchPanelBlockedTab(tab.url)) {
-    await openStandaloneSearchWindow();
+  await recordTabSearchDebug("background", "search.delivery", {
+    tabId: tab?.id || null,
+    url: tab?.url || "",
+    delivery
+  });
+
+  if (!tab?.id || delivery === TAB_SEARCH_DELIVERY.STANDALONE_WINDOW) {
+    await openStandaloneSearchWindow(
+      !tab?.id ? "no-active-tab" : "blocked-delivery",
+      {
+        delivery,
+        tabId: tab?.id || null,
+        sourceUrl: tab?.url || ""
+      }
+    );
     return;
   }
 
   const payload = { type: "open-tab-search", tabs };
 
+  if (delivery === TAB_SEARCH_DELIVERY.EXTENSION_PAGE_OVERLAY) {
+    const hashResult = await requestExtensionPageSearchOverlayViaHash(tab.id);
+    await recordTabSearchDebug("background", "search.extension-overlay.hash", {
+      tabId: tab.id,
+      ok: hashResult.ok,
+      error: hashResult.error || ""
+    });
+
+    if (hashResult.ok) {
+      return;
+    }
+
+    const overlayResult = await requestExtensionPageSearchOverlay(tab.id, tabs);
+    await recordTabSearchDebug("background", "search.extension-overlay.result", {
+      tabId: tab.id,
+      ok: overlayResult.ok,
+      error: overlayResult.error || ""
+    });
+
+    if (!overlayResult.ok) {
+      const extensionOverlayTrace = formatExtensionOverlayDebugTrace({
+        hashResult,
+        overlayResult
+      });
+
+      await openStandaloneSearchWindow("extension-overlay-failed", {
+        delivery,
+        error: overlayResult.error || "",
+        trace: extensionOverlayTrace,
+        tabId: tab.id,
+        sourceUrl: tab?.url || ""
+      });
+    }
+
+    return;
+  }
+
   try {
     await chrome.tabs.sendMessage(tab.id, payload);
+    await recordTabSearchDebug("background", "search.page-overlay.sent", { tabId: tab.id });
   } catch (_error) {
     try {
       await chrome.scripting.executeScript({
         target: { tabId: tab.id },
-        files: ["ai-provider-config.js", "content.js"]
+        files: ["tab-search-debug.js", "ai-provider-config.js", "content.js"]
       });
 
       await chrome.tabs.sendMessage(tab.id, payload);
+      await recordTabSearchDebug("background", "search.page-overlay.injected", { tabId: tab.id });
     } catch (_innerError) {
-      await openStandaloneSearchWindow();
+      await recordTabSearchDebug("background", "search.page-overlay.fallback-window", { tabId: tab.id });
+      await openStandaloneSearchWindow("page-overlay-failed", {
+        delivery,
+        tabId: tab.id,
+        sourceUrl: tab?.url || ""
+      });
     }
   }
 }
 
-async function openStandaloneSearchWindow() {
-  await chrome.windows.create({
-    url: chrome.runtime.getURL("search.html"),
+function formatExtensionOverlayDebugTrace({ hashResult, overlayResult }) {
+  const overlayAttempts = overlayResult?.attempts || {};
+
+  return [
+    `hash=${hashResult?.ok ? "ok" : (hashResult?.error || "skipped")}`,
+    `channel=${overlayAttempts.channel || "skipped"}`,
+    `storage=${overlayAttempts.storage || "skipped"}`,
+    `port=${overlayAttempts.port || "skipped"}`
+  ].join(" | ");
+}
+
+function requestExtensionPageSearchOverlayViaHash(tabId) {
+  const requestId = `options-hash-search-${Date.now()}-${extensionPageRequestId += 1}`;
+  const nextUrl = `${chrome.runtime.getURL("options.html")}${OPTIONS_PAGE_SEARCH_HASH_PREFIX}${requestId}`;
+
+  return new Promise((resolve) => {
+    const timerId = setTimeout(() => {
+      pendingExtensionPageHashRequests.delete(requestId);
+      void recordTabSearchDebug("background", "search.extension-overlay.hash.timeout", {
+        tabId,
+        requestId
+      });
+      resolve({ ok: false, error: "options-hash-timeout" });
+    }, 1200);
+
+    pendingExtensionPageHashRequests.set(requestId, {
+      resolve,
+      timerId
+    });
+
+    chrome.tabs.update(tabId, { url: nextUrl }).then(() => {
+      void recordTabSearchDebug("background", "search.extension-overlay.hash.requested", {
+        tabId,
+        requestId
+      });
+    }).catch((error) => {
+      pendingExtensionPageHashRequests.delete(requestId);
+      clearTimeout(timerId);
+      const message = error instanceof Error ? error.message : "options-hash-update-failed";
+      void recordTabSearchDebug("background", "search.extension-overlay.hash.error", {
+        tabId,
+        requestId,
+        error: message
+      });
+      resolve({ ok: false, error: message });
+    });
+  });
+}
+
+async function openStandaloneSearchWindow(reason, context) {
+  const targetUrl = buildStandaloneSearchUrl(
+    chrome.runtime.getURL("search.html"),
+    reason,
+    context
+  );
+
+  if (standaloneSearchWindowId) {
+    try {
+      const tabs = await chrome.tabs.query({ windowId: standaloneSearchWindowId });
+
+      if (tabs[0]?.id) {
+        await chrome.tabs.update(tabs[0].id, { url: targetUrl });
+      }
+
+      await chrome.windows.update(standaloneSearchWindowId, {
+        focused: true,
+        drawAttention: true
+      });
+      await recordTabSearchDebug("background", "search.standalone.reused", { windowId: standaloneSearchWindowId });
+      return;
+    } catch (_error) {
+      standaloneSearchWindowId = null;
+    }
+  }
+
+  const createdWindow = await chrome.windows.create({
+    url: targetUrl,
     type: "popup",
     width: 820,
     height: 720
+  });
+
+  standaloneSearchWindowId = createdWindow?.id || null;
+  await recordTabSearchDebug("background", "search.standalone.created", { windowId: standaloneSearchWindowId });
+}
+
+function requestExtensionPageSearchOverlay(tabId, tabs) {
+  return requestExtensionPageSearchOverlayViaChannel(tabId, tabs).then(async (channelResult) => {
+    if (channelResult.ok) {
+      return channelResult;
+    }
+
+    const storageResult = await requestExtensionPageSearchOverlayViaStorage(tabId, tabs);
+
+    if (storageResult.ok) {
+      return storageResult;
+    }
+
+    const portResult = await requestExtensionPageSearchOverlayViaPort(tabId, tabs);
+
+    if (portResult.ok) {
+      return portResult;
+    }
+
+    return {
+      ok: false,
+      attempts: {
+        channel: channelResult.ok ? "ok" : (channelResult.error || "failed"),
+        storage: storageResult.ok ? "ok" : (storageResult.error || "failed"),
+        port: portResult.ok ? "ok" : (portResult.error || "failed")
+      },
+      error: [channelResult.error, storageResult.error, portResult.error]
+        .filter(Boolean)
+        .join(" / ") || "options-overlay-unavailable"
+    };
+  });
+}
+
+function requestExtensionPageSearchOverlayViaChannel(tabId, tabs) {
+  if (!extensionPageChannel) {
+    void recordTabSearchDebug("background", "search.extension-overlay.channel.unavailable", { tabId });
+    return Promise.resolve({ ok: false, error: "options-channel-unavailable" });
+  }
+
+  const requestId = `extension-channel-search-${Date.now()}-${extensionPageRequestId += 1}`;
+
+  return new Promise((resolve) => {
+    const timerId = setTimeout(() => {
+      pendingExtensionPageChannelRequests.delete(requestId);
+      void recordTabSearchDebug("background", "search.extension-overlay.channel.timeout", {
+        tabId,
+        requestId
+      });
+      resolve({ ok: false, error: "options-channel-timeout" });
+    }, 1200);
+
+    pendingExtensionPageChannelRequests.set(requestId, {
+      resolve,
+      timerId
+    });
+
+    try {
+      void recordTabSearchDebug("background", "search.extension-overlay.channel.requested", {
+        tabId,
+        requestId,
+        tabCount: Array.isArray(tabs) ? tabs.length : 0
+      });
+      extensionPageChannel.postMessage({
+        type: "open-extension-tab-search",
+        requestId,
+        targetTabId: tabId,
+        tabs
+      });
+    } catch (error) {
+      pendingExtensionPageChannelRequests.delete(requestId);
+      clearTimeout(timerId);
+      const message = error instanceof Error ? error.message : "options-channel-post-failed";
+      void recordTabSearchDebug("background", "search.extension-overlay.channel.error", {
+        tabId,
+        requestId,
+        error: message
+      });
+      resolve({ ok: false, error: message });
+    }
+  });
+}
+
+function requestExtensionPageSearchOverlayViaStorage(tabId, tabs) {
+  const requestId = `extension-storage-search-${Date.now()}-${extensionPageRequestId += 1}`;
+
+  return new Promise((resolve) => {
+    const timerId = setTimeout(() => {
+      pendingExtensionPageStorageRequests.delete(requestId);
+      void recordTabSearchDebug("background", "search.extension-overlay.storage.timeout", {
+        tabId,
+        requestId
+      });
+      resolve({ ok: false, error: "options-storage-timeout" });
+    }, 1500);
+
+    pendingExtensionPageStorageRequests.set(requestId, {
+      resolve,
+      timerId
+    });
+
+    void recordTabSearchDebug("background", "search.extension-overlay.storage.requested", {
+      tabId,
+      requestId,
+      tabCount: Array.isArray(tabs) ? tabs.length : 0
+    });
+
+    chrome.storage.local.set({
+      [EXTENSION_PAGE_SEARCH_REQUEST_STORAGE_KEY]: {
+        requestId,
+        targetTabId: tabId,
+        tabs,
+        at: Date.now()
+      }
+    }).catch((error) => {
+      pendingExtensionPageStorageRequests.delete(requestId);
+      clearTimeout(timerId);
+      const message = error instanceof Error ? error.message : "options-storage-set-failed";
+      void recordTabSearchDebug("background", "search.extension-overlay.storage.error", {
+        tabId,
+        requestId,
+        error: message
+      });
+      resolve({ ok: false, error: message });
+    });
+  });
+}
+
+function requestExtensionPageSearchOverlayViaPort(tabId, tabs) {
+  const candidatePorts = [];
+  const mappedPort = extensionPagePorts.get(tabId);
+
+  if (mappedPort) {
+    candidatePorts.push({ port: mappedPort, source: "mapped" });
+  }
+
+  if (candidatePorts.length === 0) {
+    for (const port of extensionPageUnboundPorts) {
+      candidatePorts.push({ port, source: "unbound" });
+    }
+  }
+
+  if (candidatePorts.length === 0) {
+    void recordTabSearchDebug("background", "search.extension-overlay.no-port", { tabId });
+    return Promise.resolve({ ok: false, error: "options-port-missing" });
+  }
+
+  return tryExtensionPageOverlayPorts(candidatePorts, tabId, tabs);
+}
+
+function tryExtensionPageOverlayPorts(candidatePorts, tabId, tabs) {
+  const attempts = Array.isArray(candidatePorts) ? candidatePorts : [];
+  const errors = [];
+
+  return attempts.reduce((chain, candidate) => {
+    return chain.then(async (result) => {
+      if (result?.ok) {
+        return result;
+      }
+
+      const attemptResult = await requestExtensionPageOverlayThroughPort(candidate, tabId, tabs);
+
+      if (!attemptResult.ok && attemptResult.error) {
+        errors.push(attemptResult.error);
+      }
+
+      return attemptResult;
+    });
+  }, Promise.resolve({ ok: false, error: "" })).then((result) => {
+    if (result?.ok) {
+      return result;
+    }
+
+    return {
+      ok: false,
+      error: errors.filter(Boolean).join(" / ") || "options-port-failed"
+    };
+  });
+}
+
+function requestExtensionPageOverlayThroughPort(candidate, tabId, tabs) {
+  const port = candidate?.port;
+
+  if (!port) {
+    return Promise.resolve({ ok: false, error: "options-port-missing" });
+  }
+
+  const requestId = `extension-search-${Date.now()}-${extensionPageRequestId += 1}`;
+
+  return new Promise((resolve) => {
+    const timerId = setTimeout(() => {
+      pendingExtensionPageRequests.delete(requestId);
+      void recordTabSearchDebug("background", "search.extension-overlay.timeout", {
+        tabId,
+        requestId,
+        source: candidate?.source || "unknown"
+      });
+      resolve({ ok: false, error: "options-port-timeout" });
+    }, 1200);
+
+    pendingExtensionPageRequests.set(requestId, {
+      port,
+      resolve,
+      timerId
+    });
+
+    try {
+      void recordTabSearchDebug("background", "search.extension-overlay.requested", {
+        tabId,
+        requestId,
+        source: candidate?.source || "unknown",
+        tabCount: Array.isArray(tabs) ? tabs.length : 0
+      });
+      port.postMessage({
+        type: "open-extension-tab-search",
+        requestId,
+        targetTabId: tabId,
+        tabs
+      });
+    } catch (_error) {
+      pendingExtensionPageRequests.delete(requestId);
+      clearTimeout(timerId);
+      void recordTabSearchDebug("background", "search.extension-overlay.post-failed", { tabId, requestId });
+      resolve({ ok: false, error: "options-port-post-failed" });
+    }
   });
 }
 

--- a/content.js
+++ b/content.js
@@ -10,6 +10,7 @@ const {
   resolveAISettingsDraft,
   updateAIKeyPlaceholder
 } = globalThis.AIProviderConfig;
+const { recordTabSearchDebug = async () => {} } = globalThis.TabSearchDebug || {};
 
 const OVERLAY_ID = "__ai_tab_organizer_search_overlay__";
 const ACTIONS = ["open", "close", "bookmark_close"];
@@ -69,6 +70,9 @@ async function openTabSearch(prefetchedTabs) {
   const existing = document.getElementById(OVERLAY_ID);
 
   if (existing) {
+    await recordTabSearchDebug("content", "overlay.toggle-close", {
+      href: location.href
+    });
     existing.remove();
     return;
   }
@@ -102,14 +106,39 @@ async function openTabSearch(prefetchedTabs) {
   let isNaturalLoading = false;
 
   let t = theme.tokens;
+  const overlayHost = document.createElement("div");
+  overlayHost.id = OVERLAY_ID;
+  Object.assign(overlayHost.style, {
+    all: "initial",
+    position: "fixed",
+    inset: "0",
+    zIndex: "2147483647"
+  });
+
+  const shadowRoot = overlayHost.attachShadow({ mode: "open" });
+  const overlayStyle = document.createElement("style");
 
   async function reloadTheme() {
     theme = await getThemeTokens();
     t = theme.tokens;
   }
 
+  function updateOverlayScopeStyle() {
+    overlayStyle.textContent = [
+      ":host { all: initial; position: fixed; inset: 0; z-index: 2147483647; }",
+      "*, *::before, *::after { box-sizing: border-box; }",
+      'button, input, select, textarea { font: inherit; color: inherit; margin: 0; }',
+      "button { appearance: none; -webkit-appearance: none; }",
+      `input::placeholder { color: ${t.commandText}; opacity: 0.45; }`,
+      "@keyframes ai-tab-organizer-spin { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }",
+      "::-webkit-scrollbar { width: 4px; height: 4px; }",
+      "::-webkit-scrollbar-track { background: transparent; }",
+      "::-webkit-scrollbar-thumb { background: rgba(120,120,120,0.3); border-radius: 999px; }",
+      "::-webkit-scrollbar-thumb:hover { background: rgba(120,120,120,0.55); }"
+    ].join("\n");
+  }
+
   const overlay = document.createElement("div");
-  overlay.id = OVERLAY_ID;
   setStyles(overlay, {
     position: "fixed",
     inset: "0",
@@ -274,16 +303,28 @@ async function openTabSearch(prefetchedTabs) {
     borderTop: `1px solid ${t.border}`
   });
 
-  const placeholderStyle = document.createElement("style");
-  placeholderStyle.textContent = `#${OVERLAY_ID} input::placeholder { color: ${t.commandText}; opacity: 0.45; }`;
-  panel.appendChild(placeholderStyle);
+  updateOverlayScopeStyle();
+  shadowRoot.appendChild(overlayStyle);
   panel.appendChild(toolbar);
   panel.appendChild(list);
   panel.appendChild(footer);
   overlay.appendChild(panel);
-  document.documentElement.appendChild(overlay);
+  shadowRoot.appendChild(overlay);
+  document.documentElement.appendChild(overlayHost);
+  await recordTabSearchDebug("content", "overlay.opened", {
+    href: location.href,
+    pageType: location.href === chrome.runtime.getURL("options.html") ? "options" : "web",
+    prefetchedTabs: Boolean(prefetchedTabs),
+    tabCount: Array.isArray(tabs) ? tabs.length : 0,
+    shadow: true
+  });
 
-  const close = () => overlay.remove();
+  const close = () => {
+    void recordTabSearchDebug("content", "overlay.closed", {
+      href: location.href
+    });
+    overlayHost.remove();
+  };
 
   list.addEventListener("mouseleave", () => {
     hoveredIndex = null;
@@ -970,6 +1011,7 @@ async function openTabSearch(prefetchedTabs) {
   }
 
   function applyThemeToPanel() {
+    updateOverlayScopeStyle();
     overlay.style.background = t.overlayBg;
     panel.style.background = t.surface;
     panel.style.borderColor = t.border;
@@ -1176,6 +1218,10 @@ async function openTabSearch(prefetchedTabs) {
   rebuildRows();
   input.focus();
 }
+
+globalThis.AITabSearchOverlay = Object.assign({}, globalThis.AITabSearchOverlay, {
+  openTabSearch
+});
 
 ensureSpinnerStyle();
 

--- a/manifest.json
+++ b/manifest.json
@@ -30,6 +30,7 @@
         "<all_urls>"
       ],
       "js": [
+        "tab-search-debug.js",
         "ai-provider-config.js",
         "content.js"
       ],

--- a/options.html
+++ b/options.html
@@ -11,7 +11,10 @@
 <body class="settings-body">
   <main class="settings-shell">
     <section class="surface settings-panel compact-surface">
-      <div class="settings-page-title">设置</div>
+      <div class="settings-header">
+        <div class="settings-page-title">设置</div>
+        <button id="debug-toggle-button" class="secondary-button debug-toggle-button hidden" type="button">调试</button>
+      </div>
 
       <div class="theme-section">
         <div class="theme-colors">
@@ -94,11 +97,25 @@
         </div>
 
         <div id="status-text" class="helper-text"></div>
+
+        <div id="debug-section" class="debug-section hidden">
+          <div class="section-title">搜索调试</div>
+          <div class="helper-inline">按一次快捷键后点刷新，就能看到现在到底走的是页内浮层、设置页通道，还是独立窗口。</div>
+          <div class="button-row minimal-actions">
+            <button id="refresh-debug-button" class="secondary-button" type="button">刷新日志</button>
+            <button id="copy-debug-button" class="secondary-button" type="button">复制日志</button>
+            <button id="clear-debug-button" class="secondary-button" type="button">清空日志</button>
+          </div>
+          <pre id="debug-log-output" class="debug-log-output">暂无日志。</pre>
+        </div>
       </div>
     </section>
   </main>
   <script src="theme.js"></script>
+  <script src="tab-search-debug.js"></script>
+  <script src="tab-search-routing.js"></script>
   <script src="ai-provider-config.js"></script>
+  <script src="content.js"></script>
   <script src="options.js"></script>
 </body>
 

--- a/options.js
+++ b/options.js
@@ -1,15 +1,31 @@
+(function initializeOptionsPageScript() {
 const {
+  EXTENSION_PAGE_SEARCH_CHANNEL_NAME,
+  EXTENSION_PAGE_SEARCH_REQUEST_STORAGE_KEY,
+  EXTENSION_PAGE_SEARCH_RESPONSE_STORAGE_KEY,
+  OPTIONS_PAGE_SEARCH_HASH_PREFIX,
+  OPTIONS_PAGE_SEARCH_HASH_RESPONSE_STORAGE_KEY,
+  EXTENSION_PAGE_PORT_NAME,
+  TAB_SEARCH_DEBUG_STORAGE_KEY,
   AI_PROVIDER_STORAGE_KEY,
   CUSTOM_AI_MODEL_OPTION_VALUE,
   applyAIProviderPreset,
+  clearTabSearchDebugEvents,
   detectAIProviderPreset,
+  formatTabSearchDebugEvent,
   normalizeAIEndpoint,
   populateAIModelSelect,
   populateAIProviderSelect,
+  readTabSearchDebugEvents,
+  recordTabSearchDebug,
   resolveAIModelSelection,
   resolveAISettingsDraft,
   updateAIKeyPlaceholder
-} = globalThis.AIProviderConfig;
+} = {
+  ...globalThis.TabSearchDebug,
+  ...globalThis.TabSearchRouting,
+  ...globalThis.AIProviderConfig
+};
 
 const providerSelect = document.getElementById("provider-select");
 const endpointInput = document.getElementById("endpoint-input");
@@ -23,11 +39,72 @@ const runButton = document.getElementById("run-button");
 const statusText = document.getElementById("status-text");
 const modeToggle = document.getElementById("mode-toggle");
 const swatches = document.querySelectorAll(".theme-swatch");
+const refreshDebugButton = document.getElementById("refresh-debug-button");
+const copyDebugButton = document.getElementById("copy-debug-button");
+const clearDebugButton = document.getElementById("clear-debug-button");
+const debugLogOutput = document.getElementById("debug-log-output");
+const debugSection = document.getElementById("debug-section");
+const debugToggleButton = document.getElementById("debug-toggle-button");
+let extensionPageChannel = null;
+let extensionPagePort = null;
+let extensionPageReconnectTimerId = null;
+let optionsPageHashHandlingAttached = false;
+const debugUiEnabled = isDebugUiEnabled();
+let debugPanelOpen = false;
 
-initialize();
+window.addEventListener("error", (event) => {
+  const details = {
+    message: event.message || "Unknown error",
+    file: event.filename || "",
+    line: event.lineno || null,
+    column: event.colno || null
+  };
+  console.error("Options page error:", event.error || event.message || event);
+  void recordOptionsDebug("window.error", details);
+});
 
-populateAIProviderSelect(providerSelect);
-populateAIModelSelect(modelSelect, providerSelect.value, "");
+window.addEventListener("unhandledrejection", (event) => {
+  const reason = event.reason instanceof Error
+    ? { message: event.reason.message, stack: event.reason.stack || "" }
+    : { message: String(event.reason || "Unknown rejection") };
+  console.error("Options page rejection:", event.reason);
+  void recordOptionsDebug("window.unhandledrejection", reason);
+});
+
+void bootstrapOptionsPage();
+initializeDebugUi();
+
+chrome.storage.onChanged.addListener((changes, areaName) => {
+  if (areaName !== "local") {
+    return;
+  }
+
+  if (changes[TAB_SEARCH_DEBUG_STORAGE_KEY]) {
+    void refreshDebugOutput();
+  }
+
+  const request = changes[EXTENSION_PAGE_SEARCH_REQUEST_STORAGE_KEY]?.newValue;
+
+  if (request?.requestId) {
+    void handleStorageExtensionTabSearchRequest(request);
+  }
+});
+
+chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
+  if (message?.type !== "open-extension-tab-search") {
+    return undefined;
+  }
+
+  handleRuntimeExtensionTabSearchMessage(message)
+    .then((result) => sendResponse(result))
+    .catch((error) => {
+      const messageText = error instanceof Error ? error.message : "Unknown error";
+      void recordOptionsDebug("search.runtime.error", { error: messageText });
+      sendResponse({ ok: false, error: messageText });
+    });
+
+  return true;
+});
 
 swatches.forEach((swatch) => {
   swatch.addEventListener("click", async () => {
@@ -44,6 +121,23 @@ modeToggle.addEventListener("click", async () => {
   await chrome.storage.local.set({ themeMode: next });
   document.documentElement.dataset.themeMode = next;
   updateModeToggle(next);
+});
+
+refreshDebugButton?.addEventListener("click", async () => {
+  await refreshDebugOutput();
+  statusText.textContent = "调试日志已刷新";
+});
+
+copyDebugButton?.addEventListener("click", async () => {
+  const text = debugLogOutput?.textContent || "";
+  await navigator.clipboard.writeText(text);
+  statusText.textContent = "调试日志已复制";
+});
+
+clearDebugButton?.addEventListener("click", async () => {
+  await clearTabSearchDebugEvents();
+  await refreshDebugOutput();
+  statusText.textContent = "调试日志已清空";
 });
 
 providerSelect.addEventListener("change", () => {
@@ -118,6 +212,190 @@ runButton.addEventListener("click", async () => {
   }
 });
 
+async function bootstrapOptionsPage() {
+  try {
+    await recordOptionsDebug("bootstrap.start", {
+      href: location.href
+    });
+
+    populateAIProviderSelect(providerSelect);
+    populateAIModelSelect(modelSelect, providerSelect.value, "");
+    attachOptionsPageHashSearchHandling();
+    connectExtensionPageChannel();
+    connectExtensionPagePort("initial");
+    await initialize();
+    await recordOptionsDebug("bootstrap.ready", {
+      href: location.href
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "设置页初始化失败";
+    console.error("Failed to bootstrap options page:", error);
+    statusText.textContent = message;
+    await recordOptionsDebug("bootstrap.error", {
+      message,
+      stack: error instanceof Error ? error.stack || "" : ""
+    });
+  }
+}
+
+function initializeDebugUi() {
+  if (!debugUiEnabled) {
+    debugSection?.classList.add("hidden");
+    debugToggleButton?.classList.add("hidden");
+    return;
+  }
+
+  debugToggleButton?.classList.remove("hidden");
+  debugToggleButton?.addEventListener("click", () => {
+    debugPanelOpen = !debugPanelOpen;
+    renderDebugVisibility();
+  });
+
+  if (new URLSearchParams(location.search).get("debug") === "1") {
+    debugPanelOpen = true;
+  }
+
+  renderDebugVisibility();
+}
+
+function renderDebugVisibility() {
+  debugSection?.classList.toggle("hidden", !debugPanelOpen);
+
+  if (debugToggleButton) {
+    debugToggleButton.textContent = debugPanelOpen ? "收起调试" : "调试";
+  }
+}
+
+function isDebugUiEnabled() {
+  const manifest = chrome.runtime?.getManifest?.() || {};
+  const forceDebug = new URLSearchParams(location.search).get("debug") === "1";
+  return forceDebug || !Object.prototype.hasOwnProperty.call(manifest, "update_url");
+}
+
+function connectExtensionPageChannel() {
+  if (typeof BroadcastChannel !== "function") {
+    void recordOptionsDebug("channel.unavailable", {
+      channelName: EXTENSION_PAGE_SEARCH_CHANNEL_NAME
+    });
+    return;
+  }
+
+  if (extensionPageChannel) {
+    extensionPageChannel.close();
+  }
+
+  const channel = new BroadcastChannel(EXTENSION_PAGE_SEARCH_CHANNEL_NAME);
+  extensionPageChannel = channel;
+
+  void recordOptionsDebug("channel.connected", {
+    channelName: EXTENSION_PAGE_SEARCH_CHANNEL_NAME
+  });
+
+  channel.addEventListener("message", (event) => {
+    const message = event?.data;
+
+    if (message?.type !== "open-extension-tab-search") {
+      return;
+    }
+
+    void recordOptionsDebug("search.channel.received", {
+      requestId: message.requestId,
+      targetTabId: message.targetTabId
+    });
+
+    handleExtensionTabSearchMessage(message)
+      .then((handled) => {
+        channel.postMessage({
+          type: "open-extension-tab-search-result",
+          requestId: message.requestId,
+          ok: handled,
+          error: handled ? "" : "options-overlay-skipped"
+        });
+        return recordOptionsDebug("search.channel.result", {
+          requestId: message.requestId,
+          ok: handled
+        });
+      })
+      .catch((error) => {
+        const messageText = error instanceof Error ? error.message : "Unknown error";
+        channel.postMessage({
+          type: "open-extension-tab-search-result",
+          requestId: message.requestId,
+          ok: false,
+          error: messageText
+        });
+        return recordOptionsDebug("search.channel.error", {
+          requestId: message.requestId,
+          error: messageText
+        });
+      });
+  });
+}
+
+function attachOptionsPageHashSearchHandling() {
+  if (optionsPageHashHandlingAttached) {
+    return;
+  }
+
+  window.addEventListener("hashchange", () => {
+    void handleOptionsPageHashSearch();
+  });
+  optionsPageHashHandlingAttached = true;
+  void handleOptionsPageHashSearch();
+}
+
+async function handleOptionsPageHashSearch() {
+  const currentHash = String(location.hash || "");
+
+  if (!currentHash.startsWith(OPTIONS_PAGE_SEARCH_HASH_PREFIX)) {
+    return;
+  }
+
+  const requestId = currentHash.slice(OPTIONS_PAGE_SEARCH_HASH_PREFIX.length) || `options-hash-${Date.now()}`;
+  const nextUrl = `${location.pathname}${location.search}`;
+
+  history.replaceState(null, document.title, nextUrl);
+
+  await recordOptionsDebug("search.hash.received", {
+    requestId
+  });
+
+  try {
+    const handled = await handleExtensionTabSearchMessage({
+      requestId,
+      targetTabId: null
+    });
+
+    await chrome.storage.local.set({
+      [OPTIONS_PAGE_SEARCH_HASH_RESPONSE_STORAGE_KEY]: {
+        requestId,
+        ok: handled,
+        error: handled ? "" : "options-overlay-skipped"
+      }
+    });
+
+    await recordOptionsDebug("search.hash.result", {
+      requestId,
+      ok: handled
+    });
+  } catch (error) {
+    const messageText = error instanceof Error ? error.message : "Unknown error";
+
+    await chrome.storage.local.set({
+      [OPTIONS_PAGE_SEARCH_HASH_RESPONSE_STORAGE_KEY]: {
+        requestId,
+        ok: false,
+        error: messageText
+      }
+    });
+
+    await recordOptionsDebug("search.hash.error", {
+      requestId,
+      error: messageText
+    });
+  }
+}
+
 async function initialize() {
   const stored = await chrome.storage.local.get([
     AI_PROVIDER_STORAGE_KEY,
@@ -140,6 +418,179 @@ async function initialize() {
   updateAIKeyPlaceholder(apiKeyInput, draft.providerId);
   updateSwatchSelection(stored.themeColor || "neutral");
   updateModeToggle(stored.themeMode || "light");
+  await refreshDebugOutput();
+}
+
+function connectExtensionPagePort(strategy) {
+  if (extensionPageReconnectTimerId) {
+    clearTimeout(extensionPageReconnectTimerId);
+    extensionPageReconnectTimerId = null;
+  }
+
+  const port = chrome.runtime.connect({ name: EXTENSION_PAGE_PORT_NAME });
+  extensionPagePort = port;
+
+  registerExtensionPagePort(port, strategy);
+
+  port.onMessage.addListener((message) => {
+    if (port !== extensionPagePort || message?.type !== "open-extension-tab-search") {
+      return;
+    }
+
+    void recordOptionsDebug("search.request.received", {
+      requestId: message.requestId,
+      targetTabId: message.targetTabId
+    });
+
+    handleExtensionTabSearchMessage(message)
+      .then((handled) => {
+        postExtensionPagePortMessage(port, {
+          type: "open-extension-tab-search-result",
+          requestId: message.requestId,
+          ok: handled
+        });
+        return recordOptionsDebug("search.request.result", {
+          requestId: message.requestId,
+          ok: handled
+        });
+      })
+      .catch((error) => {
+        postExtensionPagePortMessage(port, {
+          type: "open-extension-tab-search-result",
+          requestId: message.requestId,
+          ok: false,
+          error: error instanceof Error ? error.message : "Unknown error"
+        });
+        return recordOptionsDebug("search.request.error", error);
+      });
+  });
+
+  port.onDisconnect.addListener(() => {
+    if (port !== extensionPagePort) {
+      return;
+    }
+
+    const errorMessage = chrome.runtime.lastError?.message || "";
+    extensionPagePort = null;
+    void recordOptionsDebug("port.disconnected", {
+      error: errorMessage,
+      strategy
+    });
+
+    extensionPageReconnectTimerId = setTimeout(() => {
+      void recordOptionsDebug("port.reconnecting", { delayMs: 150 });
+      connectExtensionPagePort("reconnect");
+    }, 150);
+  });
+}
+
+function postExtensionPagePortMessage(port, message) {
+  try {
+    port.postMessage(message);
+    return true;
+  } catch (error) {
+    void recordOptionsDebug("port.post.error", error);
+    return false;
+  }
+}
+
+function registerExtensionPagePort(port, strategy) {
+  postExtensionPagePortMessage(port, {
+    type: "register-options-page"
+  });
+  void recordOptionsDebug("port.registered", {
+    tabId: null,
+    strategy: `${strategy}-unbound`
+  });
+}
+
+async function handleExtensionTabSearchMessage(message) {
+  if (document.visibilityState !== "visible") {
+    await recordOptionsDebug("search.request.skipped", {
+      reason: "page-not-visible",
+      visibilityState: document.visibilityState
+    });
+    return false;
+  }
+
+  const openInlineSearch = globalThis.AITabSearchOverlay?.openTabSearch;
+
+  if (typeof openInlineSearch !== "function") {
+    throw new Error("Inline search overlay is unavailable on the settings page.");
+  }
+
+  await openInlineSearch(message.tabs);
+  await recordOptionsDebug("search.overlay.opened", {
+    targetTabId: Number(message?.targetTabId) || null,
+    requestId: message.requestId
+  });
+  return true;
+}
+
+async function handleRuntimeExtensionTabSearchMessage(message) {
+  await recordOptionsDebug("search.runtime.received", {
+    targetTabId: Number(message?.targetTabId) || null
+  });
+
+  const handled = await handleExtensionTabSearchMessage(message);
+
+  if (!handled) {
+    return { ok: false, error: "options-overlay-skipped" };
+  }
+
+  return { ok: true };
+}
+
+async function handleStorageExtensionTabSearchRequest(request) {
+  await recordOptionsDebug("search.storage.received", {
+    targetTabId: Number(request?.targetTabId) || null,
+    requestId: request.requestId
+  });
+
+  try {
+    const handled = await handleExtensionTabSearchMessage(request);
+    await chrome.storage.local.set({
+      [EXTENSION_PAGE_SEARCH_RESPONSE_STORAGE_KEY]: {
+        requestId: request.requestId,
+        ok: handled,
+        error: handled ? "" : "options-overlay-skipped",
+        currentTabId: null
+      }
+    });
+    await recordOptionsDebug("search.storage.result", {
+      requestId: request.requestId,
+      ok: handled
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unknown error";
+    await chrome.storage.local.set({
+      [EXTENSION_PAGE_SEARCH_RESPONSE_STORAGE_KEY]: {
+        requestId: request.requestId,
+        ok: false,
+        error: message,
+        currentTabId: null
+      }
+    });
+    await recordOptionsDebug("search.storage.error", {
+      requestId: request.requestId,
+      error: message
+    });
+  }
+}
+
+async function recordOptionsDebug(event, details) {
+  return recordTabSearchDebug("options", event, details);
+}
+
+async function refreshDebugOutput() {
+  if (!debugLogOutput) {
+    return;
+  }
+
+  const events = await readTabSearchDebugEvents();
+  debugLogOutput.textContent = events.length > 0
+    ? events.map((entry) => formatTabSearchDebugEvent(entry)).join("\n")
+    : "暂无日志。";
 }
 
 async function saveSettings() {
@@ -176,3 +627,4 @@ function setBusy(busy, message) {
   runButton.disabled = busy;
   statusText.textContent = message;
 }
+})();

--- a/search.html
+++ b/search.html
@@ -14,10 +14,12 @@
       <div class="eyebrow">Search</div>
       <h1>搜索标签页</h1>
       <p class="muted-copy">当前页面不支持页内面板时，会自动打开这个独立搜索窗口。</p>
+      <div id="search-debug-banner" class="search-debug-banner hidden"></div>
       <div id="search-root" style="margin-top: 18px;"></div>
     </section>
   </main>
   <script src="theme.js"></script>
+  <script src="tab-search-debug.js"></script>
   <script src="ai-provider-config.js"></script>
   <script src="search.js"></script>
 </body>

--- a/search.js
+++ b/search.js
@@ -10,6 +10,7 @@ const {
   resolveAISettingsDraft,
   updateAIKeyPlaceholder
 } = globalThis.AIProviderConfig;
+const { recordTabSearchDebug = async () => {} } = globalThis.TabSearchDebug || {};
 
 const ACTIONS = ["open", "close", "bookmark_close"];
 const NATURAL_BATCH_ACTIONS = [
@@ -23,17 +24,30 @@ initialize();
 
 async function initialize() {
   const root = document.getElementById("search-root");
+  const debugBanner = document.getElementById("search-debug-banner");
 
   if (!root) {
+    await recordTabSearchDebug("standalone", "search-root.missing");
     return;
   }
+
+  renderDebugBanner(debugBanner);
+
+  await recordTabSearchDebug("standalone", "window.opened", {
+    href: location.href
+  });
 
   const response = await chrome.runtime.sendMessage({ type: "get-tabs" });
 
   if (!response?.ok) {
+    await recordTabSearchDebug("standalone", "tabs.load.failed", response?.error || "unknown");
     root.textContent = "无法读取标签页";
     return;
   }
+
+  await recordTabSearchDebug("standalone", "tabs.loaded", {
+    tabCount: Array.isArray(response.tabs) ? response.tabs.length : 0
+  });
 
   let tabs = response.tabs || [];
   let entries = [];
@@ -978,6 +992,50 @@ async function initialize() {
   rebuildRows();
   updateHint();
   input.focus();
+}
+
+function renderDebugBanner(node) {
+  if (!node) {
+    return;
+  }
+
+  if (!isDebugUiEnabled()) {
+    node.classList.add("hidden");
+    node.textContent = "";
+    return;
+  }
+
+  const params = new URLSearchParams(location.search);
+  const reason = params.get("debug_reason");
+
+  if (!reason) {
+    node.classList.add("hidden");
+    node.textContent = "";
+    return;
+  }
+
+  const delivery = params.get("debug_delivery");
+  const error = params.get("debug_error");
+  const trace = params.get("debug_trace");
+  const tabId = params.get("debug_tab_id");
+  const sourceUrl = params.get("debug_source_url");
+
+  node.classList.remove("hidden");
+  node.textContent = [
+    `调试：这次打开了独立窗口。`,
+    `原因：${reason}`,
+    error ? `细节：${error}` : "",
+    trace ? `链路：${trace}` : "",
+    delivery ? `原始分发：${delivery}` : "",
+    tabId ? `目标 Tab：${tabId}` : "",
+    sourceUrl ? `来源页：${sourceUrl}` : ""
+  ].filter(Boolean).join(" ");
+}
+
+function isDebugUiEnabled() {
+  const manifest = chrome.runtime?.getManifest?.() || {};
+  const forceDebug = new URLSearchParams(location.search).get("debug") === "1";
+  return forceDebug || !Object.prototype.hasOwnProperty.call(manifest, "update_url");
 }
 
 ensureSpinnerStyle();

--- a/tab-search-debug.js
+++ b/tab-search-debug.js
@@ -1,0 +1,139 @@
+(function attachTabSearchDebug(root, factory) {
+  const api = factory();
+
+  root.TabSearchDebug = api;
+
+  if (typeof module !== "undefined" && module.exports) {
+    module.exports = api;
+  }
+})(typeof globalThis !== "undefined" ? globalThis : this, function createTabSearchDebug() {
+  const TAB_SEARCH_DEBUG_STORAGE_KEY = "tabSearchDebugEvents";
+  const MAX_TAB_SEARCH_DEBUG_EVENTS = 120;
+
+  function truncateDebugString(value, maxLength = 240) {
+    const text = String(value ?? "");
+    return text.length > maxLength ? `${text.slice(0, maxLength - 1)}…` : text;
+  }
+
+  function normalizeTabSearchDebugValue(value, depth = 0) {
+    if (value == null) {
+      return value;
+    }
+
+    if (typeof value === "string") {
+      return truncateDebugString(value);
+    }
+
+    if (typeof value === "number" || typeof value === "boolean") {
+      return value;
+    }
+
+    if (value instanceof Error) {
+      return {
+        name: value.name,
+        message: truncateDebugString(value.message),
+        stack: truncateDebugString(value.stack || "", 400)
+      };
+    }
+
+    if (Array.isArray(value)) {
+      if (depth >= 2) {
+        return `[Array(${value.length})]`;
+      }
+
+      return value.slice(0, 12).map((item) => normalizeTabSearchDebugValue(item, depth + 1));
+    }
+
+    if (typeof value === "object") {
+      if (depth >= 2) {
+        return "[Object]";
+      }
+
+      return Object.fromEntries(
+        Object.entries(value)
+          .slice(0, 12)
+          .map(([key, item]) => [key, normalizeTabSearchDebugValue(item, depth + 1)])
+      );
+    }
+
+    return truncateDebugString(String(value));
+  }
+
+  function createTabSearchDebugEvent(source, event, details, at) {
+    return {
+      at: at || new Date().toISOString(),
+      source: String(source || "unknown"),
+      event: String(event || "event"),
+      details: details === undefined ? undefined : normalizeTabSearchDebugValue(details)
+    };
+  }
+
+  function appendTabSearchDebugEvent(events, entry, maxSize = MAX_TAB_SEARCH_DEBUG_EVENTS) {
+    const nextEvents = Array.isArray(events) ? events.slice() : [];
+    nextEvents.push(entry);
+
+    if (nextEvents.length <= maxSize) {
+      return nextEvents;
+    }
+
+    return nextEvents.slice(nextEvents.length - maxSize);
+  }
+
+  function formatTabSearchDebugEvent(entry) {
+    const base = `[${entry?.at || ""}] ${entry?.source || "unknown"} ${entry?.event || "event"}`;
+
+    if (entry?.details === undefined) {
+      return base;
+    }
+
+    return `${base} ${JSON.stringify(entry.details)}`;
+  }
+
+  async function readTabSearchDebugEvents() {
+    if (!globalThis.chrome?.storage?.local) {
+      return [];
+    }
+
+    const stored = await chrome.storage.local.get(TAB_SEARCH_DEBUG_STORAGE_KEY);
+    return Array.isArray(stored[TAB_SEARCH_DEBUG_STORAGE_KEY]) ? stored[TAB_SEARCH_DEBUG_STORAGE_KEY] : [];
+  }
+
+  async function clearTabSearchDebugEvents() {
+    if (!globalThis.chrome?.storage?.local) {
+      return;
+    }
+
+    await chrome.storage.local.remove(TAB_SEARCH_DEBUG_STORAGE_KEY);
+  }
+
+  async function recordTabSearchDebug(source, event, details) {
+    const entry = createTabSearchDebugEvent(source, event, details);
+
+    try {
+      console.info("[TabSearchDebug]", formatTabSearchDebugEvent(entry));
+    } catch (_error) {}
+
+    if (!globalThis.chrome?.storage?.local) {
+      return entry;
+    }
+
+    const events = await readTabSearchDebugEvents();
+    const nextEvents = appendTabSearchDebugEvent(events, entry);
+    await chrome.storage.local.set({
+      [TAB_SEARCH_DEBUG_STORAGE_KEY]: nextEvents
+    });
+
+    return entry;
+  }
+
+  return {
+    TAB_SEARCH_DEBUG_STORAGE_KEY,
+    MAX_TAB_SEARCH_DEBUG_EVENTS,
+    appendTabSearchDebugEvent,
+    clearTabSearchDebugEvents,
+    createTabSearchDebugEvent,
+    formatTabSearchDebugEvent,
+    readTabSearchDebugEvents,
+    recordTabSearchDebug
+  };
+});

--- a/tab-search-routing.js
+++ b/tab-search-routing.js
@@ -1,0 +1,115 @@
+(function attachTabSearchRouting(root, factory) {
+  const api = factory();
+
+  root.TabSearchRouting = api;
+
+  if (typeof module !== "undefined" && module.exports) {
+    module.exports = api;
+  }
+})(typeof globalThis !== "undefined" ? globalThis : this, function createTabSearchRouting() {
+  const EXTENSION_PAGE_SEARCH_CHANNEL_NAME = "extension-page-tab-search";
+  const OPTIONS_PAGE_SEARCH_HASH_PREFIX = "#tab-search-";
+  const OPTIONS_PAGE_SEARCH_HASH_RESPONSE_STORAGE_KEY = "optionsPageTabSearchHashResponse";
+  const EXTENSION_PAGE_PORT_NAME = "options-page-tab-search";
+  const EXTENSION_PAGE_SEARCH_REQUEST_STORAGE_KEY = "extensionPageTabSearchRequest";
+  const EXTENSION_PAGE_SEARCH_RESPONSE_STORAGE_KEY = "extensionPageTabSearchResponse";
+  const TAB_SEARCH_DELIVERY = Object.freeze({
+    PAGE_OVERLAY: "page-overlay",
+    EXTENSION_PAGE_OVERLAY: "extension-page-overlay",
+    STANDALONE_WINDOW: "standalone-window"
+  });
+
+  function resolveTabSearchDelivery({ url, blockedProtocols, optionsPageUrl }) {
+    const normalizedUrl = String(url || "").trim();
+    const blocked = Array.isArray(blockedProtocols) ? blockedProtocols : [];
+    const normalizedOptionsPageUrl = String(optionsPageUrl || "").trim();
+
+    if (!normalizedUrl) {
+      return TAB_SEARCH_DELIVERY.STANDALONE_WINDOW;
+    }
+
+    if (blocked.some((protocol) => normalizedUrl.startsWith(protocol))) {
+      return TAB_SEARCH_DELIVERY.STANDALONE_WINDOW;
+    }
+
+    if (normalizedOptionsPageUrl && normalizedUrl.startsWith(normalizedOptionsPageUrl)) {
+      return TAB_SEARCH_DELIVERY.EXTENSION_PAGE_OVERLAY;
+    }
+
+    return TAB_SEARCH_DELIVERY.PAGE_OVERLAY;
+  }
+
+  function shouldBackgroundHandleRuntimeMessage(message) {
+    return message?.type !== "open-extension-tab-search";
+  }
+
+  function isOptionsPagePortName(name) {
+    return String(name || "") === EXTENSION_PAGE_PORT_NAME;
+  }
+
+  function normalizeTabId(value) {
+    const nextValue = Number(value);
+    return Number.isInteger(nextValue) && nextValue > 0 ? nextValue : null;
+  }
+
+  function resolveOptionsPageConnectionTabId({ senderTabId, registeredTabId }) {
+    return normalizeTabId(senderTabId) || normalizeTabId(registeredTabId);
+  }
+
+  function isExtensionPageSearchResponseMatch(response, requestId) {
+    return String(response?.requestId || "") === String(requestId || "")
+      && typeof response?.ok === "boolean";
+  }
+
+  function buildStandaloneSearchUrl(baseUrl, reason, context) {
+    const originalBaseUrl = String(baseUrl || "");
+    const url = new URL(originalBaseUrl, "https://example.invalid");
+    const details = context || {};
+
+    if (reason) {
+      url.searchParams.set("debug_reason", String(reason));
+    }
+
+    if (details.delivery) {
+      url.searchParams.set("debug_delivery", String(details.delivery));
+    }
+
+    if (details.error) {
+      url.searchParams.set("debug_error", String(details.error));
+    }
+
+    if (details.tabId != null) {
+      url.searchParams.set("debug_tab_id", String(details.tabId));
+    }
+
+    if (details.sourceUrl) {
+      url.searchParams.set("debug_source_url", String(details.sourceUrl));
+    }
+
+    if (details.trace) {
+      url.searchParams.set("debug_trace", String(details.trace));
+    }
+
+    if (originalBaseUrl.startsWith("chrome-extension://")) {
+      return `${url.protocol}//${url.host}${url.pathname}${url.search}`;
+    }
+
+    return url.toString();
+  }
+
+  return {
+    EXTENSION_PAGE_SEARCH_CHANNEL_NAME,
+    EXTENSION_PAGE_SEARCH_REQUEST_STORAGE_KEY,
+    EXTENSION_PAGE_SEARCH_RESPONSE_STORAGE_KEY,
+    OPTIONS_PAGE_SEARCH_HASH_PREFIX,
+    OPTIONS_PAGE_SEARCH_HASH_RESPONSE_STORAGE_KEY,
+    EXTENSION_PAGE_PORT_NAME,
+    TAB_SEARCH_DELIVERY,
+    buildStandaloneSearchUrl,
+    isExtensionPageSearchResponseMatch,
+    isOptionsPagePortName,
+    resolveOptionsPageConnectionTabId,
+    resolveTabSearchDelivery,
+    shouldBackgroundHandleRuntimeMessage
+  };
+});

--- a/tests/tab-search-debug.test.mjs
+++ b/tests/tab-search-debug.test.mjs
@@ -1,0 +1,39 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import debugApi from "../tab-search-debug.js";
+
+const {
+  MAX_TAB_SEARCH_DEBUG_EVENTS,
+  appendTabSearchDebugEvent,
+  createTabSearchDebugEvent,
+  formatTabSearchDebugEvent
+} = debugApi;
+
+test("caps stored tab search debug events to the configured max size", () => {
+  const events = Array.from({ length: MAX_TAB_SEARCH_DEBUG_EVENTS }, (_, index) =>
+    createTabSearchDebugEvent("background", `event-${index}`, { index }, `2026-04-08T00:00:${String(index).padStart(2, "0")}Z`)
+  );
+
+  const appended = appendTabSearchDebugEvent(
+    events,
+    createTabSearchDebugEvent("options", "latest", { step: "after-cap" }, "2026-04-08T00:10:00Z")
+  );
+
+  assert.equal(appended.length, MAX_TAB_SEARCH_DEBUG_EVENTS);
+  assert.equal(appended[0].event, "event-1");
+  assert.equal(appended.at(-1)?.event, "latest");
+});
+
+test("formats a readable single-line debug log entry", () => {
+  const line = formatTabSearchDebugEvent(
+    createTabSearchDebugEvent("content", "overlay-opened", {
+      mode: "shadow",
+      href: "https://example.com/docs"
+    }, "2026-04-08T12:34:56.000Z")
+  );
+
+  assert.equal(
+    line,
+    '[2026-04-08T12:34:56.000Z] content overlay-opened {"mode":"shadow","href":"https://example.com/docs"}'
+  );
+});

--- a/tests/tab-search-routing.test.mjs
+++ b/tests/tab-search-routing.test.mjs
@@ -1,0 +1,127 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import routing from "../tab-search-routing.js";
+
+const {
+  EXTENSION_PAGE_SEARCH_CHANNEL_NAME,
+  EXTENSION_PAGE_SEARCH_REQUEST_STORAGE_KEY,
+  EXTENSION_PAGE_SEARCH_RESPONSE_STORAGE_KEY,
+  OPTIONS_PAGE_SEARCH_HASH_PREFIX,
+  OPTIONS_PAGE_SEARCH_HASH_RESPONSE_STORAGE_KEY,
+  EXTENSION_PAGE_PORT_NAME,
+  TAB_SEARCH_DELIVERY,
+  buildStandaloneSearchUrl,
+  isExtensionPageSearchResponseMatch,
+  isOptionsPagePortName,
+  resolveOptionsPageConnectionTabId,
+  resolveTabSearchDelivery,
+  shouldBackgroundHandleRuntimeMessage
+} = routing;
+
+test("uses page overlay delivery for normal web pages", () => {
+  const delivery = resolveTabSearchDelivery({
+    url: "https://example.com/docs",
+    blockedProtocols: ["chrome:", "edge:"],
+    optionsPageUrl: "chrome-extension://test-extension/options.html"
+  });
+
+  assert.equal(delivery, TAB_SEARCH_DELIVERY.PAGE_OVERLAY);
+});
+
+test("uses extension page overlay delivery for the settings page", () => {
+  const delivery = resolveTabSearchDelivery({
+    url: "chrome-extension://test-extension/options.html",
+    blockedProtocols: ["chrome:", "edge:"],
+    optionsPageUrl: "chrome-extension://test-extension/options.html"
+  });
+
+  assert.equal(delivery, TAB_SEARCH_DELIVERY.EXTENSION_PAGE_OVERLAY);
+});
+
+test("falls back to the standalone window for blocked browser pages", () => {
+  const delivery = resolveTabSearchDelivery({
+    url: "chrome://extensions",
+    blockedProtocols: ["chrome:", "edge:"],
+    optionsPageUrl: "chrome-extension://test-extension/options.html"
+  });
+
+  assert.equal(delivery, TAB_SEARCH_DELIVERY.STANDALONE_WINDOW);
+});
+
+test("background runtime handler ignores extension page overlay handoff messages", () => {
+  assert.equal(
+    shouldBackgroundHandleRuntimeMessage({ type: "open-extension-tab-search" }),
+    false
+  );
+  assert.equal(
+    shouldBackgroundHandleRuntimeMessage({ type: "run-tab-search" }),
+    true
+  );
+});
+
+test("recognizes the dedicated options page port name", () => {
+  assert.equal(isOptionsPagePortName(EXTENSION_PAGE_PORT_NAME), true);
+  assert.equal(isOptionsPagePortName("something-else"), false);
+});
+
+test("exports the storage keys for extension page overlay handoff", () => {
+  assert.equal(EXTENSION_PAGE_SEARCH_CHANNEL_NAME, "extension-page-tab-search");
+  assert.equal(EXTENSION_PAGE_SEARCH_REQUEST_STORAGE_KEY, "extensionPageTabSearchRequest");
+  assert.equal(EXTENSION_PAGE_SEARCH_RESPONSE_STORAGE_KEY, "extensionPageTabSearchResponse");
+  assert.equal(OPTIONS_PAGE_SEARCH_HASH_PREFIX, "#tab-search-");
+  assert.equal(OPTIONS_PAGE_SEARCH_HASH_RESPONSE_STORAGE_KEY, "optionsPageTabSearchHashResponse");
+});
+
+test("builds a standalone search url with fallback debug details", () => {
+  const url = buildStandaloneSearchUrl(
+    "chrome-extension://test-extension/search.html",
+    "extension-overlay-timeout",
+    {
+      delivery: TAB_SEARCH_DELIVERY.EXTENSION_PAGE_OVERLAY,
+      error: "options-port-timeout",
+      trace: "hash=options-hash-timeout | channel=options-channel-timeout | storage=options-storage-timeout | port=options-port-timeout",
+      tabId: 321,
+      sourceUrl: "chrome-extension://test-extension/options.html"
+    }
+  );
+
+  assert.equal(
+    url,
+    "chrome-extension://test-extension/search.html?debug_reason=extension-overlay-timeout&debug_delivery=extension-page-overlay&debug_error=options-port-timeout&debug_tab_id=321&debug_source_url=chrome-extension%3A%2F%2Ftest-extension%2Foptions.html&debug_trace=hash%3Doptions-hash-timeout+%7C+channel%3Doptions-channel-timeout+%7C+storage%3Doptions-storage-timeout+%7C+port%3Doptions-port-timeout"
+  );
+});
+
+test("prefers the sender tab id when binding an options page connection", () => {
+  assert.equal(
+    resolveOptionsPageConnectionTabId({
+      senderTabId: 88,
+      registeredTabId: 42
+    }),
+    88
+  );
+});
+
+test("falls back to a registered tab id when sender tab id is missing", () => {
+  assert.equal(
+    resolveOptionsPageConnectionTabId({
+      senderTabId: null,
+      registeredTabId: 42
+    }),
+    42
+  );
+});
+
+test("matches only storage responses for the active overlay request id", () => {
+  assert.equal(
+    isExtensionPageSearchResponseMatch({ requestId: "req-1", ok: true }, "req-1"),
+    true
+  );
+  assert.equal(
+    isExtensionPageSearchResponseMatch({ requestId: "req-2", ok: true }, "req-1"),
+    false
+  );
+  assert.equal(
+    isExtensionPageSearchResponseMatch({ requestId: "req-1" }, "req-1"),
+    false
+  );
+});

--- a/ui.css
+++ b/ui.css
@@ -241,6 +241,18 @@ body {
   padding-bottom: 48px;
 }
 
+.settings-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.debug-toggle-button {
+  flex: 0 0 auto;
+  min-width: 72px;
+}
+
 .surface {
   margin-bottom: 12px;
   padding: 16px;
@@ -493,6 +505,38 @@ textarea {
   min-height: 20px;
   margin-top: 12px;
   font-size: 13px;
+}
+
+.debug-section {
+  margin-top: 18px;
+  padding-top: 14px;
+  border-top: 1px solid var(--border-item);
+}
+
+.debug-log-output {
+  margin: 10px 0 0;
+  padding: 12px;
+  min-height: 140px;
+  max-height: 320px;
+  overflow: auto;
+  border: 1px solid var(--border-light);
+  border-radius: 14px;
+  background: var(--bg-input);
+  color: var(--text-primary);
+  font: 11px/1.5 ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.search-debug-banner {
+  margin-top: 12px;
+  padding: 10px 12px;
+  border: 1px solid var(--border-light);
+  border-radius: 12px;
+  background: var(--bg-input);
+  color: var(--text-primary);
+  font-size: 12px;
+  line-height: 1.5;
 }
 
 .large-field {


### PR DESCRIPTION
## 背景

这个改动主要处理一个体验不一致的问题：

- 在普通网页里按 `Search tabs and jump to a matching page` 快捷键，会打开页内悬浮搜索面板。
- 在扩展自己的设置页 `options.html` 里按同一个快捷键，却会回退到独立浏览器窗口。
- 如果连续按快捷键，还会反复打开多个独立窗口。

排查后确认，设置页并不是样式问题，而是设置页脚本一开始就没有正常执行：`options.html` 同时加载了 `content.js` 和 `options.js`，两个经典脚本在同一个页面作用域里声明了同名顶层常量，导致 `options.js` 直接抛出 `Identifier 'AI_PROVIDER_STORAGE_KEY' has already been declared`，后续的设置页搜索浮层逻辑、监听和调试入口都没有机会注册。

## 这次改了什么

1. 修复设置页脚本冲突
- 将 `options.js` 包装进独立作用域，避免和 `content.js` 的顶层变量发生冲突。
- 让设置页脚本可以正常完成初始化，确保快捷键触发后能够真正打开页内悬浮搜索面板。

2. 统一搜索浮层分发逻辑
- 抽离并补全普通网页、扩展设置页、受限页面三类场景的路由判断。
- 设置页优先走页内浮层分发；浏览器限制页面仍然保留独立搜索窗口作为兜底。
- 独立搜索窗口增加复用控制，避免连续触发时反复新开窗口。

3. 补充调试与测试
- 新增统一的搜索调试模块，方便记录搜索分发过程中的关键事件。
- 为搜索路由和调试模块补充测试，覆盖设置页、普通网页、浏览器受限页等分支。
- 将调试入口收敛成单独入口，并限制为开发环境默认显示；非开发环境默认不展示，如需临时查看可通过 `?debug=1` 打开。

4. 清理排查期间的临时实现
- 去掉排查问题时加入的临时探针脚本和实验性的页面内快捷键分支。
- 保留已经验证有效的设置页浮层主路径和必要的后备逻辑。

## 影响范围

- 设置页按快捷键时，体验与普通网页保持一致，都会显示页内悬浮搜索面板。
- 设置页不再因为脚本初始化失败而退回到独立窗口。
- 即使真的需要走独立窗口，也不会因为重复触发而连续打开多个窗口。
- 调试能力仍然保留，但默认只服务开发环境，不会干扰正常用户界面。

## 验证

已执行：

```bash
node --check options.js
node --check search.js
node --experimental-default-type=module --check background.js
node --test tests/*.test.mjs
```

结果：以上检查全部通过，测试 `23/23` 通过。
