### PR TITLE
fix: 修复设置页快捷键搜索的脚本作用域冲突

### DIFF
--- a/options.js
+++ b/options.js
@@ -1,3 +1,4 @@
+(() => {
 const {
   AI_PROVIDER_STORAGE_KEY,
   CUSTOM_AI_MODEL_OPTION_VALUE,
@@ -176,3 +177,4 @@ function setBusy(busy, message) {
   runButton.disabled = busy;
   statusText.textContent = message;
 }
+})();

--- a/tests/options-page-scope.test.mjs
+++ b/tests/options-page-scope.test.mjs
@@ -1,0 +1,134 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import vm from "node:vm";
+
+const repoRoot = path.resolve(import.meta.dirname, "..");
+
+function createFakeElement() {
+  return {
+    value: "",
+    checked: false,
+    disabled: false,
+    textContent: "",
+    dataset: {},
+    style: {},
+    classList: {
+      toggle() {},
+      add() {},
+      remove() {}
+    },
+    addEventListener() {},
+    removeEventListener() {},
+    setAttribute() {}
+  };
+}
+
+function createExecutionContext() {
+  const elementCache = new Map();
+  const swatches = [createFakeElement(), createFakeElement()];
+
+  const document = {
+    documentElement: { dataset: {} },
+    getElementById(id) {
+      if (!elementCache.has(id)) {
+        elementCache.set(id, createFakeElement());
+      }
+
+      return elementCache.get(id);
+    },
+    querySelectorAll(selector) {
+      if (selector === ".theme-swatch") {
+        return swatches;
+      }
+
+      return [];
+    }
+  };
+
+  const context = {
+    console,
+    setTimeout,
+    clearTimeout,
+    document,
+    window: null,
+    globalThis: null,
+    chrome: {
+      runtime: {
+        onMessage: {
+          addListener() {}
+        },
+        sendMessage: async () => ({ ok: true })
+      },
+      storage: {
+        local: {
+          get: async () => ({}),
+          set: async () => {}
+        }
+      }
+    },
+    AIProviderConfig: null
+  };
+
+  context.window = context;
+  context.globalThis = context;
+  context.AIProviderConfig = {
+    AI_PROVIDER_STORAGE_KEY: "aiProvider",
+    CUSTOM_AI_MODEL_OPTION_VALUE: "__custom__",
+    applyAIProviderPreset(providerId, draft) {
+      return {
+        ...draft,
+        endpoint: draft.endpoint || "https://api.openai.com/v1/chat/completions",
+        model: draft.model || "gpt-4.1-mini",
+        providerId
+      };
+    },
+    detectAIProviderPreset() {
+      return "openai";
+    },
+    normalizeAIEndpoint(value) {
+      return value || "https://api.openai.com/v1/chat/completions";
+    },
+    populateAIModelSelect(element, providerId, modelValue) {
+      element.value = modelValue || "gpt-4.1-mini";
+      element.dataset.providerId = providerId || "openai";
+    },
+    populateAIProviderSelect(element) {
+      element.value = "openai";
+    },
+    resolveAIModelSelection(providerId, modelValue) {
+      return {
+        selectedValue: modelValue || "gpt-4.1-mini",
+        customValue: "",
+        options: [{ value: "gpt-4.1-mini", label: "gpt-4.1-mini" }],
+        providerId
+      };
+    },
+    resolveAISettingsDraft(stored) {
+      return {
+        providerId: stored.aiProvider || "openai",
+        endpoint: stored.aiEndpoint || "https://api.openai.com/v1/chat/completions",
+        apiKey: stored.aiApiKey || "",
+        model: stored.aiModel || "gpt-4.1-mini",
+        preference: stored.aiPreference || "",
+        experimentalTitleRewriteEnabled: Boolean(stored.experimentalTitleRewriteEnabled)
+      };
+    },
+    updateAIKeyPlaceholder() {}
+  };
+  context.globalThis.AIProviderConfig = context.AIProviderConfig;
+
+  return vm.createContext(context);
+}
+
+test("options page script can run after content script in the same page scope", () => {
+  const contentScript = fs.readFileSync(path.join(repoRoot, "content.js"), "utf8");
+  const optionsScript = fs.readFileSync(path.join(repoRoot, "options.js"), "utf8");
+  const context = createExecutionContext();
+
+  assert.doesNotThrow(() => {
+    vm.runInContext(contentScript, context, { filename: "content.js" });
+    vm.runInContext(optionsScript, context, { filename: "options.js" });
+  });
+});


### PR DESCRIPTION
## 背景

这个 PR 是从 #10 中拆出来的最小修复版，只处理设置页快捷键搜索在扩展页面内失效的问题，不再包含路由、调试或额外通信链路调整。

问题原因是 `options.js` 和 `content.js` 会在同一个页面作用域里执行，两个脚本都在顶层声明了同名常量，导致设置页初始化时直接报错，后续搜索浮层逻辑也不会正常执行。

## 修复内容

- 用 IIFE 包裹 `options.js`，把设置页脚本的变量作用域限制在自身内部
- 增加一个回归测试，验证 `content.js` 和 `options.js` 在同一页面作用域下执行时不再发生重复声明错误

## 复现步骤

1. 打开扩展设置页 `options.html`
2. 在设置页里触发快捷键搜索
3. 修复前，控制台会出现类似 `Identifier 'AI_PROVIDER_STORAGE_KEY' has already been declared` 的错误
4. 修复后，设置页脚本可以正常初始化，快捷键搜索不再因为这类作用域冲突直接失败

## 验证

- `node --test tests/*.test.mjs`
