### PR TITLE
test: 补齐后台核心逻辑测试，给整理与批量操作加回归保护

### DIFF
--- a/background-normalizers.mjs
+++ b/background-normalizers.mjs
@@ -1,0 +1,136 @@
+const TAB_GROUP_COLORS = ["grey", "blue", "red", "yellow", "green", "pink", "purple", "cyan", "orange"];
+export const TITLE_REWRITE_MAX_LENGTH = 24;
+
+export function normalizeOrganizationPlan(plan, tabs) {
+  const tabList = Array.isArray(tabs) ? tabs : [];
+  const validIds = new Set(tabList.map((tab) => tab.id));
+  const assignedIds = new Set();
+  const normalizedGroups = [];
+  const sourceGroups = Array.isArray(plan?.groups) ? plan.groups : [];
+
+  for (const group of sourceGroups) {
+    const tabIds = (Array.isArray(group?.tabIds) ? group.tabIds : [])
+      .map((value) => Number(value))
+      .filter((id) => validIds.has(id) && !assignedIds.has(id));
+
+    if (tabIds.length < 2) {
+      continue;
+    }
+
+    tabIds.forEach((id) => assignedIds.add(id));
+    normalizedGroups.push({
+      name: truncate(String(group?.name || "Group").trim() || "Group", 40),
+      color: TAB_GROUP_COLORS.includes(group?.color) ? group.color : pickGroupColor(normalizedGroups.length),
+      collapsed: Boolean(group?.collapsed),
+      tabIds
+    });
+  }
+
+  const ungroupedTabIds = (Array.isArray(plan?.ungroupedTabIds) ? plan.ungroupedTabIds : [])
+    .map((value) => Number(value))
+    .filter((id) => validIds.has(id) && !assignedIds.has(id));
+
+  ungroupedTabIds.forEach((id) => assignedIds.add(id));
+
+  for (const tab of tabList) {
+    if (!assignedIds.has(tab.id)) {
+      ungroupedTabIds.push(tab.id);
+      assignedIds.add(tab.id);
+    }
+  }
+
+  return { groups: normalizedGroups, ungroupedTabIds };
+}
+
+export function normalizeBatchSelection(result, tabs) {
+  const tabList = Array.isArray(tabs) ? tabs : [];
+  const validIds = new Set(tabList.map((tab) => tab.id));
+  const selectedIdSet = new Set(
+    (Array.isArray(result?.selectedTabIds) ? result.selectedTabIds : [])
+      .map((value) => Number(value))
+      .filter((id) => validIds.has(id))
+  );
+
+  const selectedTabs = tabList.filter((tab) => selectedIdSet.has(tab.id));
+
+  return {
+    tabs: selectedTabs,
+    rationale: String(result?.rationale || "").trim(),
+    suggestedLabel: truncate(String(result?.suggestedLabel || "").trim() || deriveBatchLabel("", selectedTabs), 40)
+  };
+}
+
+export function normalizeTitleRewritePlan(result, tabs) {
+  const tabList = Array.isArray(tabs) ? tabs : [];
+  const validIds = new Set(tabList.map((tab) => tab.id));
+  const seenIds = new Set();
+  const tabsById = new Map(tabList.map((tab) => [tab.id, tab]));
+  const source = Array.isArray(result?.titles) ? result.titles : [];
+
+  return source
+    .map((item) => ({
+      tabId: Number(item?.tabId),
+      title: cleanupRewrittenTitle(
+        truncate(String(item?.rewrittenTitle || "").trim(), TITLE_REWRITE_MAX_LENGTH),
+        tabsById.get(Number(item?.tabId))
+      )
+    }))
+    .filter((item) => {
+      if (!validIds.has(item.tabId) || seenIds.has(item.tabId) || !item.title) {
+        return false;
+      }
+
+      seenIds.add(item.tabId);
+      return true;
+    });
+}
+
+export function cleanupRewrittenTitle(title, tab) {
+  const normalized = String(title || "")
+    .replace(/\s*[|·•\-—]\s*/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+
+  if (!normalized) {
+    return "";
+  }
+
+  const domain = safeGetDomain(tab?.url || "")
+    .replace(/^www\./i, "")
+    .split(".")[0]
+    .toLowerCase();
+
+  if (!domain) {
+    return normalized;
+  }
+
+  const parts = normalized.split(/\s+/).filter((part) => part.toLowerCase() !== domain);
+  return truncate(parts.join(" ").trim() || normalized, TITLE_REWRITE_MAX_LENGTH);
+}
+
+export function safeGetDomain(url) {
+  try {
+    return new URL(url).hostname;
+  } catch (_error) {
+    return "";
+  }
+}
+
+export function truncate(value, maxLength) {
+  return value.length > maxLength ? `${value.slice(0, maxLength - 1)}…` : value;
+}
+
+export function deriveBatchLabel(query, tabs) {
+  const normalized = String(query || "").trim();
+
+  if (normalized) {
+    return truncate(normalized, 40);
+  }
+
+  const firstDomain = safeGetDomain(tabs[0]?.url || "");
+  return firstDomain || "Arc Tabs";
+}
+
+function pickGroupColor(index) {
+  return TAB_GROUP_COLORS[index % TAB_GROUP_COLORS.length];
+}

--- a/background.js
+++ b/background.js
@@ -1,8 +1,16 @@
+import {
+  TITLE_REWRITE_MAX_LENGTH,
+  deriveBatchLabel,
+  normalizeBatchSelection,
+  normalizeOrganizationPlan,
+  normalizeTitleRewritePlan,
+  safeGetDomain,
+  truncate
+} from "./background-normalizers.mjs";
+
 const DEFAULT_AI_ENDPOINT = "https://api.openai.com/v1/chat/completions";
 const DEFAULT_AI_MODEL = "gpt-4.1-mini";
-const TAB_GROUP_COLORS = ["grey", "blue", "red", "yellow", "green", "pink", "purple", "cyan", "orange"];
 const SEARCH_PANEL_BLOCKED_PROTOCOLS = ["about:", "brave:", "chrome:", "edge:", "vivaldi:"];
-const TITLE_REWRITE_MAX_LENGTH = 24;
 
 let organizationState = createIdleState();
 
@@ -472,63 +480,6 @@ function buildOrganizationPrompt(tabs, preference) {
   );
 }
 
-function normalizeOrganizationPlan(plan, tabs) {
-  const validIds = new Set(tabs.map((tab) => tab.id));
-  const assignedIds = new Set();
-  const normalizedGroups = [];
-  const sourceGroups = Array.isArray(plan?.groups) ? plan.groups : [];
-
-  for (const group of sourceGroups) {
-    const tabIds = (Array.isArray(group?.tabIds) ? group.tabIds : [])
-      .map((value) => Number(value))
-      .filter((id) => validIds.has(id) && !assignedIds.has(id));
-
-    if (tabIds.length < 2) {
-      continue;
-    }
-
-    tabIds.forEach((id) => assignedIds.add(id));
-    normalizedGroups.push({
-      name: truncate(String(group?.name || "Group").trim() || "Group", 40),
-      color: TAB_GROUP_COLORS.includes(group?.color) ? group.color : pickGroupColor(normalizedGroups.length),
-      collapsed: Boolean(group?.collapsed),
-      tabIds
-    });
-  }
-
-  const ungroupedTabIds = (Array.isArray(plan?.ungroupedTabIds) ? plan.ungroupedTabIds : [])
-    .map((value) => Number(value))
-    .filter((id) => validIds.has(id) && !assignedIds.has(id));
-
-  ungroupedTabIds.forEach((id) => assignedIds.add(id));
-
-  for (const tab of tabs) {
-    if (!assignedIds.has(tab.id)) {
-      ungroupedTabIds.push(tab.id);
-      assignedIds.add(tab.id);
-    }
-  }
-
-  return { groups: normalizedGroups, ungroupedTabIds };
-}
-
-function normalizeBatchSelection(result, tabs) {
-  const validIds = new Set(tabs.map((tab) => tab.id));
-  const selectedIdSet = new Set(
-    (Array.isArray(result?.selectedTabIds) ? result.selectedTabIds : [])
-      .map((value) => Number(value))
-      .filter((id) => validIds.has(id))
-  );
-
-  const selectedTabs = tabs.filter((tab) => selectedIdSet.has(tab.id));
-
-  return {
-    tabs: selectedTabs,
-    rationale: String(result?.rationale || "").trim(),
-    suggestedLabel: truncate(String(result?.suggestedLabel || "").trim() || deriveBatchLabel("", selectedTabs), 40)
-  };
-}
-
 async function applyOrganizationPlan(plan, candidateTabs, allWindowTabs) {
   const pinnedCount = allWindowTabs.filter((tab) => tab.pinned).length;
   const desiredOrder = [...plan.groups.flatMap((group) => group.tabIds), ...plan.ungroupedTabIds];
@@ -671,30 +622,6 @@ async function rewriteTabTitlesWithAI(tabs, settings) {
   return results.filter(Boolean).length;
 }
 
-function normalizeTitleRewritePlan(result, tabs) {
-  const validIds = new Set(tabs.map((tab) => tab.id));
-  const seenIds = new Set();
-  const tabsById = new Map(tabs.map((tab) => [tab.id, tab]));
-  const source = Array.isArray(result?.titles) ? result.titles : [];
-
-  return source
-    .map((item) => ({
-      tabId: Number(item?.tabId),
-      title: cleanupRewrittenTitle(
-        truncate(String(item?.rewrittenTitle || "").trim(), TITLE_REWRITE_MAX_LENGTH),
-        tabsById.get(Number(item?.tabId))
-      )
-    }))
-    .filter((item) => {
-      if (!validIds.has(item.tabId) || seenIds.has(item.tabId) || !item.title) {
-        return false;
-      }
-
-      seenIds.add(item.tabId);
-      return true;
-    });
-}
-
 function shouldConsiderTitleRewrite(tab) {
   const title = String(tab?.title || "").trim();
   const url = String(tab?.url || "");
@@ -757,29 +684,6 @@ async function applyTemporaryTitleRewrite(tabId, title) {
   } catch (_error) {
     return false;
   }
-}
-
-function cleanupRewrittenTitle(title, tab) {
-  const normalized = String(title || "")
-    .replace(/\s*[|·•\-—]\s*/g, " ")
-    .replace(/\s+/g, " ")
-    .trim();
-
-  if (!normalized) {
-    return "";
-  }
-
-  const domain = safeGetDomain(tab?.url || "")
-    .replace(/^www\./i, "")
-    .split(".")[0]
-    .toLowerCase();
-
-  if (!domain) {
-    return normalized;
-  }
-
-  const parts = normalized.split(/\s+/).filter((part) => part.toLowerCase() !== domain);
-  return truncate(parts.join(" ").trim() || normalized, TITLE_REWRITE_MAX_LENGTH);
 }
 
 async function ensureBookmarkFolder(name) {
@@ -941,33 +845,6 @@ function normalizeEndpoint(endpoint) {
   } catch (_error) {
     return value;
   }
-}
-
-function safeGetDomain(url) {
-  try {
-    return new URL(url).hostname;
-  } catch (_error) {
-    return "";
-  }
-}
-
-function pickGroupColor(index) {
-  return TAB_GROUP_COLORS[index % TAB_GROUP_COLORS.length];
-}
-
-function truncate(value, maxLength) {
-  return value.length > maxLength ? `${value.slice(0, maxLength - 1)}…` : value;
-}
-
-function deriveBatchLabel(query, tabs) {
-  const normalized = String(query || "").trim();
-
-  if (normalized) {
-    return truncate(normalized, 40);
-  }
-
-  const firstDomain = safeGetDomain(tabs[0]?.url || "");
-  return firstDomain || "Arc Tabs";
 }
 
 function getCandidateTabs(tabs) {

--- a/tests/background-normalizers.test.mjs
+++ b/tests/background-normalizers.test.mjs
@@ -1,0 +1,90 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  cleanupRewrittenTitle,
+  normalizeBatchSelection,
+  normalizeOrganizationPlan,
+  normalizeTitleRewritePlan
+} from "../background-normalizers.mjs";
+
+test("normalizeOrganizationPlan 会过滤无效分组、去重并补齐遗漏标签页", () => {
+  const tabs = [
+    { id: 101, url: "https://a.test" },
+    { id: 102, url: "https://b.test" },
+    { id: 103, url: "https://c.test" },
+    { id: 104, url: "https://d.test" }
+  ];
+
+  const plan = normalizeOrganizationPlan(
+    {
+      groups: [
+        { name: "Work", color: "blue", collapsed: false, tabIds: [101, 102, 999] },
+        { name: "Solo", color: "red", collapsed: false, tabIds: [103] },
+        { name: "Dupes", color: "green", collapsed: false, tabIds: [101, 104] }
+      ],
+      ungroupedTabIds: [102]
+    },
+    tabs
+  );
+
+  assert.deepEqual(plan.groups, [
+    { name: "Work", color: "blue", collapsed: false, tabIds: [101, 102] }
+  ]);
+  assert.deepEqual(plan.ungroupedTabIds, [103, 104]);
+});
+
+test("normalizeBatchSelection 会保留有效标签页并补默认标签名", () => {
+  const tabs = [
+    { id: 1, title: "Docs", url: "https://docs.example.com/page" },
+    { id: 2, title: "Mail", url: "https://mail.example.com/inbox" }
+  ];
+
+  const result = normalizeBatchSelection(
+    {
+      selectedTabIds: [2, 2, 999],
+      rationale: "These tabs match the request.",
+      suggestedLabel: ""
+    },
+    tabs
+  );
+
+  assert.deepEqual(
+    result.tabs.map((tab) => tab.id),
+    [2]
+  );
+  assert.equal(result.rationale, "These tabs match the request.");
+  assert.equal(result.suggestedLabel, "mail.example.com");
+});
+
+test("normalizeTitleRewritePlan 会清理标题、去掉重复项并忽略无效条目", () => {
+  const tabs = [
+    { id: 1, title: "Inbox - Gmail", url: "https://mail.google.com/mail/u/0/#inbox" },
+    { id: 2, title: "Pull Request · GitHub", url: "https://github.com/openai/openai/pull/1" }
+  ];
+
+  const result = normalizeTitleRewritePlan(
+    {
+      titles: [
+        { tabId: 1, rewrittenTitle: "mail 收件箱" },
+        { tabId: 1, rewrittenTitle: "重复项" },
+        { tabId: 2, rewrittenTitle: "Pull Request · GitHub" },
+        { tabId: 999, rewrittenTitle: "Ignore me" }
+      ]
+    },
+    tabs
+  );
+
+  assert.deepEqual(result, [
+    { tabId: 1, title: "收件箱" },
+    { tabId: 2, title: "Pull Request" }
+  ]);
+});
+
+test("cleanupRewrittenTitle 会去掉站点名前缀和多余分隔符", () => {
+  assert.equal(
+    cleanupRewrittenTitle("GitHub · Pull Request", {
+      url: "https://github.com/openai/openai/pull/1"
+    }),
+    "Pull Request"
+  );
+});


### PR DESCRIPTION
## 变更说明
- 把后台里和分组、批量选择、标题简写有关的规范化逻辑抽到 `background-normalizers.mjs`
- 给 `normalizeOrganizationPlan`、`normalizeBatchSelection`、`normalizeTitleRewritePlan`、`cleanupRewrittenTitle` 补上 Node 回归测试
- 保持 `background.js` 继续负责流程编排，让纯逻辑可以独立验证

## 背景
- 这些规则以前直接写在 service worker 里，测试很难覆盖到
- 只要后面继续改整理流程、批量操作或标题简写，就容易把去重、补齐遗漏标签页、默认标签名和标题清理规则改坏却没及时发现

## 验证
- `node --test tests/*.mjs`
- `git diff --check HEAD~1 HEAD`

Closes #14
