### PR TITLE
fix: 统一 AI endpoint 归一化逻辑，避免配置层和后台各走一套

### DIFF
--- a/background-ai-settings.mjs
+++ b/background-ai-settings.mjs
@@ -1,0 +1,21 @@
+import "./ai-provider-config.js";
+
+const aiProviderConfig = globalThis.AIProviderConfig;
+
+if (!aiProviderConfig) {
+  throw new Error("AIProviderConfig is unavailable.");
+}
+
+const { DEFAULT_AI_ENDPOINT, DEFAULT_AI_MODEL, normalizeAIEndpoint } = aiProviderConfig;
+
+export function resolveBackgroundAISettings(stored) {
+  const source = stored || {};
+
+  return {
+    endpoint: normalizeAIEndpoint(source.aiEndpoint || DEFAULT_AI_ENDPOINT),
+    apiKey: source.aiApiKey || "",
+    model: source.aiModel || DEFAULT_AI_MODEL,
+    preference: source.aiPreference || "",
+    experimentalTitleRewriteEnabled: Boolean(source.experimentalTitleRewriteEnabled)
+  };
+}

--- a/background.js
+++ b/background.js
@@ -1,5 +1,5 @@
-const DEFAULT_AI_ENDPOINT = "https://api.openai.com/v1/chat/completions";
-const DEFAULT_AI_MODEL = "gpt-4.1-mini";
+import { resolveBackgroundAISettings } from "./background-ai-settings.mjs";
+
 const TAB_GROUP_COLORS = ["grey", "blue", "red", "yellow", "green", "pink", "purple", "cyan", "orange"];
 const SEARCH_PANEL_BLOCKED_PROTOCOLS = ["about:", "brave:", "chrome:", "edge:", "vivaldi:"];
 const TITLE_REWRITE_MAX_LENGTH = 24;
@@ -572,13 +572,7 @@ async function getAISettings() {
     "experimentalTitleRewriteEnabled"
   ]);
 
-  return {
-    endpoint: normalizeEndpoint(stored.aiEndpoint || DEFAULT_AI_ENDPOINT),
-    apiKey: stored.aiApiKey || "",
-    model: stored.aiModel || DEFAULT_AI_MODEL,
-    preference: stored.aiPreference || "",
-    experimentalTitleRewriteEnabled: Boolean(stored.experimentalTitleRewriteEnabled)
-  };
+  return resolveBackgroundAISettings(stored);
 }
 
 async function getSearchableTabs() {
@@ -920,26 +914,6 @@ function parseJsonFromText(text) {
     }
 
     throw new Error("AI 返回的不是合法 JSON。");
-  }
-}
-
-function normalizeEndpoint(endpoint) {
-  const value = String(endpoint || "").trim();
-
-  if (!value) {
-    return DEFAULT_AI_ENDPOINT;
-  }
-
-  try {
-    const url = new URL(value);
-
-    if (url.pathname === "/" || url.pathname === "" || url.pathname === "/v1" || url.pathname === "/v1/") {
-      url.pathname = "/v1/chat/completions";
-    }
-
-    return url.toString();
-  } catch (_error) {
-    return value;
   }
 }
 

--- a/tests/background-ai-settings.test.mjs
+++ b/tests/background-ai-settings.test.mjs
@@ -1,0 +1,19 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { resolveBackgroundAISettings } from "../background-ai-settings.mjs";
+
+test("resolveBackgroundAISettings 会复用共享 endpoint 归一化规则", () => {
+  const settings = resolveBackgroundAISettings({
+    aiEndpoint: "https://example.com/custom/v1",
+    aiApiKey: "sk-test",
+    aiModel: "",
+    aiPreference: "group by task",
+    experimentalTitleRewriteEnabled: true
+  });
+
+  assert.equal(settings.endpoint, "https://example.com/custom/v1/chat/completions");
+  assert.equal(settings.apiKey, "sk-test");
+  assert.equal(settings.model, "gpt-4.1-mini");
+  assert.equal(settings.preference, "group by task");
+  assert.equal(settings.experimentalTitleRewriteEnabled, true);
+});


### PR DESCRIPTION
## 变更说明
- 新增 `background-ai-settings.mjs`，让后台读取设置时直接复用 `ai-provider-config.js` 里的 endpoint 归一化逻辑
- 删除 `background.js` 内部那份单独维护的 `normalizeEndpoint`
- 补上后台设置解析测试，覆盖自定义兼容接口地址会自动补全 `/chat/completions` 的场景

## 背景
- 设置页保存时和后台真正发请求时，各自走了一套 endpoint 规则
- 像 `https://example.com/custom/v1` 这种自定义兼容地址，设置页会补成完整接口，后台以前却不会，实际请求地址和界面显示会对不上

## 验证
- `node --test tests/*.mjs`
- `git diff --check HEAD~1 HEAD`

Closes #16
