### PR TITLE
refactor: 提取 content/search 共用搜索核心，减少双份状态机和逻辑分叉

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@
 
 - `manifest.json`: 扩展权限、弹窗、设置页、快捷键
 - `ai-provider-config.js`: AI 服务商预置和接口归一化逻辑
+- `search-inline-settings.js`: 搜索入口共用的设置读写逻辑
+- `search-core.js`: 页内搜索和独立搜索窗口共用的搜索规则与动作逻辑
 - `background.js`: AI 调用、排序和 tab group 应用逻辑
 - `background.js`: 也负责自然语言筛选 tab、批量分组/删除/书签
 - `content.js`: 页面内标签页搜索面板

--- a/background.js
+++ b/background.js
@@ -102,7 +102,7 @@ async function openTabSearch() {
     try {
       await chrome.scripting.executeScript({
         target: { tabId: tab.id },
-        files: ["ai-provider-config.js", "content.js"]
+        files: ["ai-provider-config.js", "search-inline-settings.js", "search-core.js", "content.js"]
       });
 
       await chrome.tabs.sendMessage(tab.id, payload);

--- a/content.js
+++ b/content.js
@@ -1,18 +1,25 @@
 const {
-  AI_PROVIDER_STORAGE_KEY,
   CUSTOM_AI_MODEL_OPTION_VALUE,
   applyAIProviderPreset,
   detectAIProviderPreset,
-  normalizeAIEndpoint,
   populateAIModelSelect,
   populateAIProviderSelect,
   resolveAIModelSelection,
-  resolveAISettingsDraft,
   updateAIKeyPlaceholder
 } = globalThis.AIProviderConfig;
+const { loadInlineSettings, saveInlineSettings } = globalThis.AITabInlineSettings;
+const {
+  SEARCH_ACTIONS,
+  buildEntries,
+  buildNaturalEntries,
+  cycleAction,
+  defaultActionForEntry,
+  normalizeIndex,
+  supportsActions
+} = globalThis.AITabSearchCore;
 
 const OVERLAY_ID = "__ai_tab_organizer_search_overlay__";
-const ACTIONS = ["open", "close", "bookmark_close"];
+const ACTIONS = SEARCH_ACTIONS;
 const NATURAL_BATCH_ACTIONS = [
   { action: "bookmark_close", label: "关闭全部并收藏" },
   { action: "delete", label: "关闭所有" },
@@ -1291,88 +1298,6 @@ function updateActionSelection(buttons, selectedAction, accent, tokens) {
   });
 }
 
-function buildEntries(tabs, query) {
-  const entries = [];
-  const trimmed = query.trim();
-  const normalized = trimmed.toLowerCase();
-  const settingsMatched = isSettingsCommand(trimmed, normalized);
-
-  if (settingsMatched) {
-    entries.push({
-      id: "command-settings",
-      kind: "command",
-      command: "settings",
-      title: "设置",
-      subtitle: "设置主题色、服务商、AI 接口和整理偏好"
-    });
-  }
-
-  if (settingsMatched) {
-    return entries;
-  }
-
-  if (normalized === "arrange") {
-    entries.push({
-      id: "command-arrange",
-      kind: "command",
-      command: "arrange",
-      title: "整理标签页",
-      subtitle: "智能整理并分组所有标签页"
-    });
-  }
-
-  const matchingTabs = filterTabs(tabs, trimmed).map((tab) => ({
-    id: `tab-${tab.id}`,
-    kind: "tab",
-    tabId: tab.id,
-    title: tab.title,
-    subtitle: tab.url,
-    favIconUrl: tab.favIconUrl || "",
-    lastAccessed: tab.lastAccessed || null
-  }));
-
-  entries.push(...matchingTabs);
-
-  const fallbackTarget = matchingTabs.length === 0 && trimmed ? buildFallbackTarget(trimmed) : null;
-
-  if (fallbackTarget) {
-    entries.push({
-      id: `fallback-${fallbackTarget.value}`,
-      kind: "url",
-      url: fallbackTarget.value,
-      title: fallbackTarget.title,
-      subtitle: fallbackTarget.subtitle,
-      isSearch: fallbackTarget.title === "搜索"
-    });
-  }
-
-  if (shouldShowNaturalSearchCommand(trimmed, normalized)) {
-    const naturalEntry = {
-      id: `natural-${trimmed}`,
-      kind: "command",
-      command: "natural-search",
-      title: "自然语言智能搜索",
-      subtitle: "“所有谷歌文档”、“3天没打开过的标签”"
-    };
-    const insertIndex = fallbackTarget ? entries.length : Math.min(1, entries.length);
-    entries.splice(insertIndex, 0, naturalEntry);
-  }
-
-  return entries;
-}
-
-function buildNaturalEntries(preview) {
-  return (preview?.tabs || []).map((tab) => ({
-    id: `tab-${tab.id}`,
-    kind: "tab",
-    tabId: tab.id,
-    title: tab.title,
-    subtitle: tab.url,
-    favIconUrl: tab.favIconUrl || "",
-    lastAccessed: tab.lastAccessed || null
-  }));
-}
-
 function formatLastAccessed(lastAccessed) {
   if (!lastAccessed) return null;
   const minutes = Math.floor((Date.now() - lastAccessed) / 60000);
@@ -1382,65 +1307,6 @@ function formatLastAccessed(lastAccessed) {
   if (hours < 24) return `${hours} 小时前访问`;
   const days = Math.floor(hours / 24);
   return `${days} 天前访问`;
-}
-
-function defaultActionForEntry(entry) {
-  return entry.kind === "tab" ? "open" : "run";
-}
-
-function supportsActions(entry) {
-  return entry?.kind === "tab";
-}
-
-function normalizeIndex(index, entries) {
-  if (index === -1) {
-    return -1;
-  }
-
-  if (entries.length === 0) {
-    return 0;
-  }
-
-  return Math.max(0, Math.min(index, entries.length - 1));
-}
-
-function cycleAction(currentAction, direction) {
-  if (!currentAction) {
-    return direction === "backward" ? ACTIONS[ACTIONS.length - 1] : ACTIONS[0];
-  }
-
-  const currentIndex = ACTIONS.indexOf(currentAction);
-
-  if (currentIndex === -1) {
-    return ACTIONS[0];
-  }
-
-  if (direction === "backward") {
-    return ACTIONS[(currentIndex - 1 + ACTIONS.length) % ACTIONS.length];
-  }
-
-  return ACTIONS[(currentIndex + 1) % ACTIONS.length];
-}
-
-function shouldShowNaturalSearchCommand(query, normalizedQuery) {
-  if (!query || normalizedQuery === "arrange") {
-    return false;
-  }
-
-  return getNaturalSearchScore(query) >= 4;
-}
-
-function getNaturalSearchScore(value) {
-  return Array.from(value).reduce((total, char) => total + (/[\u3400-\u9fff]/u.test(char) ? 2 : 1), 0);
-}
-
-function isSettingsCommand(query, normalizedQuery) {
-  return (
-    query.includes("设置") ||
-    normalizedQuery.startsWith("set") ||
-    normalizedQuery.includes("settings") ||
-    normalizedQuery.includes("setting")
-  );
 }
 
 function isCaretAtEnd(input) {
@@ -1732,32 +1598,6 @@ function createThemePicker(tokens, currentTheme, onChange) {
   return row;
 }
 
-async function loadInlineSettings() {
-  const stored = await chrome.storage.local.get([
-    AI_PROVIDER_STORAGE_KEY,
-    "aiEndpoint",
-    "aiApiKey",
-    "aiModel",
-    "aiPreference",
-    "experimentalTitleRewriteEnabled"
-  ]);
-
-  return resolveAISettingsDraft(stored);
-}
-
-async function saveInlineSettings(settings) {
-  const endpoint = normalizeAIEndpoint(settings.endpoint);
-
-  await chrome.storage.local.set({
-    [AI_PROVIDER_STORAGE_KEY]: settings.providerId || detectAIProviderPreset(endpoint),
-    aiEndpoint: endpoint,
-    aiApiKey: String(settings.apiKey || "").trim(),
-    aiModel: String(settings.model || "").trim(),
-    aiPreference: String(settings.preference || "").trim(),
-    experimentalTitleRewriteEnabled: Boolean(settings.experimentalTitleRewriteEnabled)
-  });
-}
-
 function ensureSpinnerStyle() {
   if (document.getElementById("__ai_tab_organizer_spinner_style__")) {
     return;
@@ -1774,75 +1614,6 @@ function ensureSpinnerStyle() {
     `#${OVERLAY_ID} ::-webkit-scrollbar-thumb:hover { background: rgba(120,120,120,0.55) !important; }`
   ].join("\n");
   (document.head || document.documentElement).appendChild(style);
-}
-
-function filterTabs(tabs, query) {
-  if (!query) {
-    return tabs;
-  }
-
-  const tokens = query.toLowerCase().split(/\s+/).filter(Boolean);
-
-  return tabs
-    .map((tab) => {
-      const haystack = `${tab.title} ${tab.url}`.toLowerCase();
-      const score = tokens.reduce((total, token) => {
-        if (haystack.includes(token)) {
-          return total + (String(tab.title || "").toLowerCase().includes(token) ? 3 : 1);
-        }
-
-        return total;
-      }, 0);
-
-      return { ...tab, score };
-    })
-    .filter((tab) => tab.score > 0)
-    .sort((left, right) => right.score - left.score);
-}
-
-function normalizeUrl(value) {
-  if (!value || /\s/.test(value)) {
-    return null;
-  }
-
-  try {
-    const url = value.includes("://") ? new URL(value) : new URL(`https://${value}`);
-    return /^https?:$/.test(url.protocol) ? url.toString() : null;
-  } catch (_error) {
-    return null;
-  }
-}
-
-function buildFallbackTarget(value) {
-  const normalized = isLikelyUrl(value) ? normalizeUrl(value) : null;
-
-  if (normalized) {
-    return {
-      value: normalized,
-      title: "打开网址",
-      subtitle: normalized
-    };
-  }
-
-  return {
-    value,
-    title: "搜索",
-    subtitle: value
-  };
-}
-
-function isLikelyUrl(value) {
-  const input = String(value || "").trim();
-
-  if (!input || /\s/.test(input)) {
-    return false;
-  }
-
-  if (/^https?:\/\//i.test(input)) {
-    return true;
-  }
-
-  return /^(localhost(?::\d+)?|(\d{1,3}\.){3}\d{1,3}(?::\d+)?|[a-z0-9-]+(\.[a-z0-9-]+)+)(\/.*)?$/i.test(input);
 }
 
 function setStyles(node, styles) {

--- a/manifest.json
+++ b/manifest.json
@@ -31,6 +31,8 @@
       ],
       "js": [
         "ai-provider-config.js",
+        "search-inline-settings.js",
+        "search-core.js",
         "content.js"
       ],
       "run_at": "document_idle"

--- a/search-core.js
+++ b/search-core.js
@@ -1,0 +1,244 @@
+(function attachTabSearchCore(root, factory) {
+  const api = factory();
+
+  root.AITabSearchCore = api;
+
+  if (typeof module !== "undefined" && module.exports) {
+    module.exports = api;
+  }
+})(typeof globalThis !== "undefined" ? globalThis : this, function createTabSearchCore() {
+  const SEARCH_ACTIONS = Object.freeze(["open", "close", "bookmark_close"]);
+
+  function buildEntries(tabs, query) {
+    const entries = [];
+    const trimmed = String(query || "").trim();
+    const normalized = trimmed.toLowerCase();
+    const settingsMatched = isSettingsCommand(trimmed, normalized);
+
+    if (settingsMatched) {
+      entries.push({
+        id: "command-settings",
+        kind: "command",
+        command: "settings",
+        title: "设置",
+        subtitle: "设置主题色、服务商、AI 接口和整理偏好"
+      });
+    }
+
+    if (settingsMatched) {
+      return entries;
+    }
+
+    if (normalized === "arrange") {
+      entries.push({
+        id: "command-arrange",
+        kind: "command",
+        command: "arrange",
+        title: "整理标签页",
+        subtitle: "智能整理并分组所有标签页"
+      });
+    }
+
+    const matchingTabs = filterTabs(Array.isArray(tabs) ? tabs : [], trimmed).map((tab) => ({
+      id: `tab-${tab.id}`,
+      kind: "tab",
+      tabId: tab.id,
+      title: tab.title,
+      subtitle: tab.url,
+      favIconUrl: tab.favIconUrl || "",
+      lastAccessed: tab.lastAccessed || null
+    }));
+
+    entries.push(...matchingTabs);
+
+    const fallbackTarget = matchingTabs.length === 0 && trimmed ? buildFallbackTarget(trimmed) : null;
+
+    if (fallbackTarget) {
+      entries.push({
+        id: `fallback-${fallbackTarget.value}`,
+        kind: "url",
+        url: fallbackTarget.value,
+        title: fallbackTarget.title,
+        subtitle: fallbackTarget.subtitle,
+        isSearch: fallbackTarget.title === "搜索"
+      });
+    }
+
+    if (shouldShowNaturalSearchCommand(trimmed, normalized)) {
+      const naturalEntry = {
+        id: `natural-${trimmed}`,
+        kind: "command",
+        command: "natural-search",
+        title: "自然语言智能搜索",
+        subtitle: "“所有谷歌文档”、“3天没打开过的标签”"
+      };
+      const insertIndex = fallbackTarget ? entries.length : Math.min(1, entries.length);
+      entries.splice(insertIndex, 0, naturalEntry);
+    }
+
+    return entries;
+  }
+
+  function buildNaturalEntries(preview) {
+    return (preview?.tabs || []).map((tab) => ({
+      id: `tab-${tab.id}`,
+      kind: "tab",
+      tabId: tab.id,
+      title: tab.title,
+      subtitle: tab.url,
+      favIconUrl: tab.favIconUrl || "",
+      lastAccessed: tab.lastAccessed || null
+    }));
+  }
+
+  function defaultActionForEntry(entry) {
+    return entry.kind === "tab" ? "open" : "run";
+  }
+
+  function supportsActions(entry) {
+    return entry?.kind === "tab";
+  }
+
+  function normalizeIndex(index, entries) {
+    if (index === -1) {
+      return -1;
+    }
+
+    if ((entries || []).length === 0) {
+      return 0;
+    }
+
+    return Math.max(0, Math.min(index, entries.length - 1));
+  }
+
+  function cycleAction(currentAction, direction) {
+    if (!currentAction) {
+      return direction === "backward" ? SEARCH_ACTIONS[SEARCH_ACTIONS.length - 1] : SEARCH_ACTIONS[0];
+    }
+
+    const currentIndex = SEARCH_ACTIONS.indexOf(currentAction);
+
+    if (currentIndex === -1) {
+      return SEARCH_ACTIONS[0];
+    }
+
+    if (direction === "backward") {
+      return SEARCH_ACTIONS[(currentIndex - 1 + SEARCH_ACTIONS.length) % SEARCH_ACTIONS.length];
+    }
+
+    return SEARCH_ACTIONS[(currentIndex + 1) % SEARCH_ACTIONS.length];
+  }
+
+  function shouldShowNaturalSearchCommand(query, normalizedQuery) {
+    if (!query || normalizedQuery === "arrange") {
+      return false;
+    }
+
+    return getNaturalSearchScore(query) >= 4;
+  }
+
+  function getNaturalSearchScore(value) {
+    return Array.from(String(value || "")).reduce(
+      (total, char) => total + (/[\u3400-\u9fff]/u.test(char) ? 2 : 1),
+      0
+    );
+  }
+
+  function isSettingsCommand(query, normalizedQuery) {
+    return (
+      String(query || "").includes("设置") ||
+      normalizedQuery.startsWith("set") ||
+      normalizedQuery.includes("settings") ||
+      normalizedQuery.includes("setting")
+    );
+  }
+
+  function filterTabs(tabs, query) {
+    if (!query) {
+      return tabs;
+    }
+
+    const tokens = String(query)
+      .toLowerCase()
+      .split(/\s+/)
+      .filter(Boolean);
+
+    return tabs
+      .map((tab) => {
+        const haystack = `${tab.title} ${tab.url}`.toLowerCase();
+        const score = tokens.reduce((total, token) => {
+          if (haystack.includes(token)) {
+            return total + (String(tab.title || "").toLowerCase().includes(token) ? 3 : 1);
+          }
+
+          return total;
+        }, 0);
+
+        return { ...tab, score };
+      })
+      .filter((tab) => tab.score > 0)
+      .sort((left, right) => right.score - left.score);
+  }
+
+  function normalizeUrl(value) {
+    if (!value || /\s/.test(value)) {
+      return null;
+    }
+
+    try {
+      const url = value.includes("://") ? new URL(value) : new URL(`https://${value}`);
+      return /^https?:$/.test(url.protocol) ? url.toString() : null;
+    } catch (_error) {
+      return null;
+    }
+  }
+
+  function buildFallbackTarget(value) {
+    const normalized = isLikelyUrl(value) ? normalizeUrl(value) : null;
+
+    if (normalized) {
+      return {
+        value: normalized,
+        title: "打开网址",
+        subtitle: normalized
+      };
+    }
+
+    return {
+      value,
+      title: "搜索",
+      subtitle: value
+    };
+  }
+
+  function isLikelyUrl(value) {
+    const input = String(value || "").trim();
+
+    if (!input || /\s/.test(input)) {
+      return false;
+    }
+
+    if (/^https?:\/\//i.test(input)) {
+      return true;
+    }
+
+    return /^(localhost(?::\d+)?|(\d{1,3}\.){3}\d{1,3}(?::\d+)?|[a-z0-9-]+(\.[a-z0-9-]+)+)(\/.*)?$/i.test(input);
+  }
+
+  return Object.freeze({
+    SEARCH_ACTIONS,
+    buildEntries,
+    buildFallbackTarget,
+    buildNaturalEntries,
+    cycleAction,
+    defaultActionForEntry,
+    filterTabs,
+    getNaturalSearchScore,
+    isLikelyUrl,
+    isSettingsCommand,
+    normalizeIndex,
+    normalizeUrl,
+    shouldShowNaturalSearchCommand,
+    supportsActions
+  });
+});

--- a/search-inline-settings.js
+++ b/search-inline-settings.js
@@ -1,0 +1,56 @@
+(function attachInlineSearchSettings(root, factory) {
+  const api = factory(root);
+
+  root.AITabInlineSettings = api;
+
+  if (typeof module !== "undefined" && module.exports) {
+    module.exports = api;
+  }
+})(typeof globalThis !== "undefined" ? globalThis : this, function createInlineSearchSettings(root) {
+  const INLINE_SETTINGS_STORAGE_SUFFIX_KEYS = Object.freeze([
+    "aiEndpoint",
+    "aiApiKey",
+    "aiModel",
+    "aiPreference",
+    "experimentalTitleRewriteEnabled"
+  ]);
+
+  function getInlineSettingsStorageKeys(providerConfig) {
+    const config = providerConfig || root.AIProviderConfig;
+    return [config.AI_PROVIDER_STORAGE_KEY, ...INLINE_SETTINGS_STORAGE_SUFFIX_KEYS];
+  }
+
+  function buildInlineSettingsPayload(settings, providerConfig) {
+    const config = providerConfig || root.AIProviderConfig;
+    const source = settings || {};
+    const endpoint = config.normalizeAIEndpoint(source.endpoint);
+
+    return {
+      [config.AI_PROVIDER_STORAGE_KEY]: source.providerId || config.detectAIProviderPreset(endpoint),
+      aiEndpoint: endpoint,
+      aiApiKey: String(source.apiKey || "").trim(),
+      aiModel: String(source.model || "").trim(),
+      aiPreference: String(source.preference || "").trim(),
+      experimentalTitleRewriteEnabled: Boolean(source.experimentalTitleRewriteEnabled)
+    };
+  }
+
+  async function loadInlineSettings(storageArea, providerConfig) {
+    const storage = storageArea || root.chrome?.storage?.local;
+    const config = providerConfig || root.AIProviderConfig;
+    const stored = await storage.get(getInlineSettingsStorageKeys(config));
+    return config.resolveAISettingsDraft(stored);
+  }
+
+  async function saveInlineSettings(settings, storageArea, providerConfig) {
+    const storage = storageArea || root.chrome?.storage?.local;
+    await storage.set(buildInlineSettingsPayload(settings, providerConfig || root.AIProviderConfig));
+  }
+
+  return Object.freeze({
+    buildInlineSettingsPayload,
+    getInlineSettingsStorageKeys,
+    loadInlineSettings,
+    saveInlineSettings
+  });
+});

--- a/search.html
+++ b/search.html
@@ -19,6 +19,8 @@
   </main>
   <script src="theme.js"></script>
   <script src="ai-provider-config.js"></script>
+  <script src="search-inline-settings.js"></script>
+  <script src="search-core.js"></script>
   <script src="search.js"></script>
 </body>
 

--- a/search.js
+++ b/search.js
@@ -1,17 +1,24 @@
 const {
-  AI_PROVIDER_STORAGE_KEY,
   CUSTOM_AI_MODEL_OPTION_VALUE,
   applyAIProviderPreset,
   detectAIProviderPreset,
-  normalizeAIEndpoint,
   populateAIModelSelect,
   populateAIProviderSelect,
   resolveAIModelSelection,
-  resolveAISettingsDraft,
   updateAIKeyPlaceholder
 } = globalThis.AIProviderConfig;
+const { loadInlineSettings, saveInlineSettings } = globalThis.AITabInlineSettings;
+const {
+  SEARCH_ACTIONS,
+  buildEntries,
+  buildNaturalEntries,
+  cycleAction,
+  defaultActionForEntry,
+  normalizeIndex,
+  supportsActions
+} = globalThis.AITabSearchCore;
 
-const ACTIONS = ["open", "close", "bookmark_close"];
+const ACTIONS = SEARCH_ACTIONS;
 const NATURAL_BATCH_ACTIONS = [
   { action: "bookmark_close", label: "关闭并加入收藏" },
   { action: "delete", label: "关闭搜索到的Tab" },
@@ -1089,144 +1096,6 @@ function updateActionSelection(buttons, selectedAction) {
   });
 }
 
-function buildEntries(tabs, query) {
-  const entries = [];
-  const trimmed = query.trim();
-  const normalized = trimmed.toLowerCase();
-  const settingsMatched = isSettingsCommand(trimmed, normalized);
-
-  if (settingsMatched) {
-    entries.push({
-      id: "command-settings",
-      kind: "command",
-      command: "settings",
-      title: "设置",
-      subtitle: "设置主题色、服务商、AI 接口和整理偏好"
-    });
-  }
-
-  if (settingsMatched) {
-    return entries;
-  }
-
-  if (normalized === "arrange") {
-    entries.push({
-      id: "command-arrange",
-      kind: "command",
-      command: "arrange",
-      title: "整理标签页",
-      subtitle: "智能整理并分组所有标签页"
-    });
-  }
-
-  const matchingTabs = filterTabs(tabs, trimmed).map((tab) => ({
-    id: `tab-${tab.id}`,
-    kind: "tab",
-    tabId: tab.id,
-    title: tab.title,
-    subtitle: tab.url,
-    favIconUrl: tab.favIconUrl || ""
-  }));
-
-  entries.push(...matchingTabs);
-
-  const fallbackTarget = matchingTabs.length === 0 && trimmed ? buildFallbackTarget(trimmed) : null;
-
-  if (fallbackTarget) {
-    entries.push({
-      id: `fallback-${fallbackTarget.value}`,
-      kind: "url",
-      url: fallbackTarget.value,
-      title: fallbackTarget.title,
-      subtitle: fallbackTarget.subtitle
-    });
-  }
-
-  if (shouldShowNaturalSearchCommand(trimmed, normalized)) {
-    const naturalEntry = {
-      id: `natural-${trimmed}`,
-      kind: "command",
-      command: "natural-search",
-      title: "自然语言智能搜索",
-      subtitle: "“所有谷歌文档”、“3天没打开过的标签”"
-    };
-    const insertIndex = fallbackTarget ? entries.length : Math.min(1, entries.length);
-    entries.splice(insertIndex, 0, naturalEntry);
-  }
-
-  return entries;
-}
-
-function buildNaturalEntries(preview) {
-  return (preview?.tabs || []).map((tab) => ({
-    id: `tab-${tab.id}`,
-    kind: "tab",
-    tabId: tab.id,
-    title: tab.title,
-    subtitle: tab.url,
-    favIconUrl: tab.favIconUrl || ""
-  }));
-}
-
-function defaultActionForEntry(entry) {
-  return entry.kind === "tab" ? "open" : "run";
-}
-
-function supportsActions(entry) {
-  return entry?.kind === "tab";
-}
-
-function normalizeIndex(index, entries) {
-  if (index === -1) {
-    return -1;
-  }
-
-  if (entries.length === 0) {
-    return 0;
-  }
-
-  return Math.max(0, Math.min(index, entries.length - 1));
-}
-
-function cycleAction(currentAction, direction) {
-  if (!currentAction) {
-    return direction === "backward" ? ACTIONS[ACTIONS.length - 1] : ACTIONS[0];
-  }
-
-  const currentIndex = ACTIONS.indexOf(currentAction);
-
-  if (currentIndex === -1) {
-    return ACTIONS[0];
-  }
-
-  if (direction === "backward") {
-    return ACTIONS[(currentIndex - 1 + ACTIONS.length) % ACTIONS.length];
-  }
-
-  return ACTIONS[(currentIndex + 1) % ACTIONS.length];
-}
-
-function shouldShowNaturalSearchCommand(query, normalizedQuery) {
-  if (!query || normalizedQuery === "arrange") {
-    return false;
-  }
-
-  return getNaturalSearchScore(query) >= 4;
-}
-
-function getNaturalSearchScore(value) {
-  return Array.from(value).reduce((total, char) => total + (/[\u3400-\u9fff]/u.test(char) ? 2 : 1), 0);
-}
-
-function isSettingsCommand(query, normalizedQuery) {
-  return (
-    query.includes("设置") ||
-    normalizedQuery.startsWith("set") ||
-    normalizedQuery.includes("settings") ||
-    normalizedQuery.includes("setting")
-  );
-}
-
 function isCaretAtEnd(input) {
   return input.selectionStart === input.selectionEnd && input.selectionEnd === input.value.length;
 }
@@ -1399,32 +1268,6 @@ function createSettingsToggle(label, helper) {
   return { wrapper, input };
 }
 
-async function loadInlineSettings() {
-  const stored = await chrome.storage.local.get([
-    AI_PROVIDER_STORAGE_KEY,
-    "aiEndpoint",
-    "aiApiKey",
-    "aiModel",
-    "aiPreference",
-    "experimentalTitleRewriteEnabled"
-  ]);
-
-  return resolveAISettingsDraft(stored);
-}
-
-async function saveInlineSettings(settings) {
-  const endpoint = normalizeAIEndpoint(settings.endpoint);
-
-  await chrome.storage.local.set({
-    [AI_PROVIDER_STORAGE_KEY]: settings.providerId || detectAIProviderPreset(endpoint),
-    aiEndpoint: endpoint,
-    aiApiKey: String(settings.apiKey || "").trim(),
-    aiModel: String(settings.model || "").trim(),
-    aiPreference: String(settings.preference || "").trim(),
-    experimentalTitleRewriteEnabled: Boolean(settings.experimentalTitleRewriteEnabled)
-  });
-}
-
 function ensureSpinnerStyle() {
   if (document.getElementById("__ai_tab_organizer_spinner_style__")) {
     return;
@@ -1434,75 +1277,6 @@ function ensureSpinnerStyle() {
   style.id = "__ai_tab_organizer_spinner_style__";
   style.textContent = "@keyframes ai-tab-organizer-spin { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }";
   (document.head || document.documentElement).appendChild(style);
-}
-
-function filterTabs(tabs, query) {
-  if (!query) {
-    return tabs;
-  }
-
-  const tokens = query.toLowerCase().split(/\s+/).filter(Boolean);
-
-  return tabs
-    .map((tab) => {
-      const haystack = `${tab.title} ${tab.url}`.toLowerCase();
-      const score = tokens.reduce((total, token) => {
-        if (haystack.includes(token)) {
-          return total + (String(tab.title || "").toLowerCase().includes(token) ? 3 : 1);
-        }
-
-        return total;
-      }, 0);
-
-      return { ...tab, score };
-    })
-    .filter((tab) => tab.score > 0)
-    .sort((left, right) => right.score - left.score);
-}
-
-function normalizeUrl(value) {
-  if (!value || /\s/.test(value)) {
-    return null;
-  }
-
-  try {
-    const url = value.includes("://") ? new URL(value) : new URL(`https://${value}`);
-    return /^https?:$/.test(url.protocol) ? url.toString() : null;
-  } catch (_error) {
-    return null;
-  }
-}
-
-function buildFallbackTarget(value) {
-  const normalized = isLikelyUrl(value) ? normalizeUrl(value) : null;
-
-  if (normalized) {
-    return {
-      value: normalized,
-      title: "打开网址",
-      subtitle: normalized
-    };
-  }
-
-  return {
-    value,
-    title: "搜索",
-    subtitle: value
-  };
-}
-
-function isLikelyUrl(value) {
-  const input = String(value || "").trim();
-
-  if (!input || /\s/.test(input)) {
-    return false;
-  }
-
-  if (/^https?:\/\//i.test(input)) {
-    return true;
-  }
-
-  return /^(localhost(?::\d+)?|(\d{1,3}\.){3}\d{1,3}(?::\d+)?|[a-z0-9-]+(\.[a-z0-9-]+)+)(\/.*)?$/i.test(input);
 }
 
 function setStyles(node, styles) {

--- a/tests/options-page-scope.test.mjs
+++ b/tests/options-page-scope.test.mjs
@@ -68,7 +68,9 @@ function createExecutionContext() {
         }
       }
     },
-    AIProviderConfig: null
+    AIProviderConfig: null,
+    AITabInlineSettings: null,
+    AITabSearchCore: null
   };
 
   context.window = context;
@@ -118,6 +120,21 @@ function createExecutionContext() {
     updateAIKeyPlaceholder() {}
   };
   context.globalThis.AIProviderConfig = context.AIProviderConfig;
+  context.AITabInlineSettings = {
+    loadInlineSettings: async () => context.AIProviderConfig.resolveAISettingsDraft({}),
+    saveInlineSettings: async () => {}
+  };
+  context.globalThis.AITabInlineSettings = context.AITabInlineSettings;
+  context.AITabSearchCore = {
+    SEARCH_ACTIONS: ["open", "close", "bookmark_close"],
+    buildEntries: () => [],
+    buildNaturalEntries: () => [],
+    cycleAction: () => "open",
+    defaultActionForEntry: () => "open",
+    normalizeIndex: () => 0,
+    supportsActions: () => true
+  };
+  context.globalThis.AITabSearchCore = context.AITabSearchCore;
 
   return vm.createContext(context);
 }

--- a/tests/search-core.test.mjs
+++ b/tests/search-core.test.mjs
@@ -1,0 +1,57 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import searchCore from "../search-core.js";
+
+const {
+  SEARCH_ACTIONS,
+  buildEntries,
+  buildNaturalEntries,
+  cycleAction,
+  defaultActionForEntry,
+  normalizeIndex,
+  supportsActions
+} = searchCore;
+
+test("buildEntries 遇到设置指令时只返回设置命令", () => {
+  const entries = buildEntries(
+    [{ id: 1, title: "Docs", url: "https://docs.example.com", favIconUrl: "" }],
+    "settings"
+  );
+
+  assert.deepEqual(entries, [
+    {
+      id: "command-settings",
+      kind: "command",
+      command: "settings",
+      title: "设置",
+      subtitle: "设置主题色、服务商、AI 接口和整理偏好"
+    }
+  ]);
+});
+
+test("buildEntries 会在无匹配时插入自然语言搜索和兜底打开项", () => {
+  const entries = buildEntries([], "找出三天没打开的标签");
+
+  assert.equal(entries[0].kind, "url");
+  assert.equal(entries[0].title, "搜索");
+  assert.equal(entries[0].isSearch, true);
+  assert.equal(entries[1].command, "natural-search");
+});
+
+test("cycleAction 会按共享动作列表循环切换", () => {
+  assert.equal(cycleAction(null, "forward"), SEARCH_ACTIONS[0]);
+  assert.equal(cycleAction("open", "backward"), SEARCH_ACTIONS[SEARCH_ACTIONS.length - 1]);
+  assert.equal(cycleAction("bookmark_close", "forward"), SEARCH_ACTIONS[0]);
+});
+
+test("共享条目辅助函数会给标签页返回可执行动作", () => {
+  const previewEntries = buildNaturalEntries({
+    tabs: [{ id: 7, title: "Mail", url: "https://mail.example.com", favIconUrl: "" }]
+  });
+
+  assert.equal(previewEntries[0].kind, "tab");
+  assert.equal(supportsActions(previewEntries[0]), true);
+  assert.equal(defaultActionForEntry(previewEntries[0]), "open");
+  assert.equal(normalizeIndex(10, previewEntries), 0);
+  assert.equal(normalizeIndex(-1, previewEntries), -1);
+});

--- a/tests/search-inline-settings.test.mjs
+++ b/tests/search-inline-settings.test.mjs
@@ -1,0 +1,74 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import providerConfig from "../ai-provider-config.js";
+import inlineSettings from "../search-inline-settings.js";
+
+const { buildInlineSettingsPayload, loadInlineSettings, saveInlineSettings } = inlineSettings;
+
+test("buildInlineSettingsPayload 会统一保存时的 endpoint 和 provider", () => {
+  const payload = buildInlineSettingsPayload(
+    {
+      providerId: "",
+      endpoint: "https://example.com/custom/v1",
+      apiKey: " sk-test ",
+      model: " custom-model ",
+      preference: " group by task ",
+      experimentalTitleRewriteEnabled: 1
+    },
+    providerConfig
+  );
+
+  assert.equal(payload.aiProviderPresetId, "custom");
+  assert.equal(payload.aiEndpoint, "https://example.com/custom/v1/chat/completions");
+  assert.equal(payload.aiApiKey, "sk-test");
+  assert.equal(payload.aiModel, "custom-model");
+  assert.equal(payload.aiPreference, "group by task");
+  assert.equal(payload.experimentalTitleRewriteEnabled, true);
+});
+
+test("loadInlineSettings 和 saveInlineSettings 会复用同一套设置规则", async () => {
+  let savedPayload = null;
+
+  const storage = {
+    async get() {
+      return {
+        aiProviderPresetId: "openrouter",
+        aiEndpoint: "https://openrouter.ai/api/v1",
+        aiApiKey: "sk-or-v1",
+        aiModel: "",
+        aiPreference: "group by task",
+        experimentalTitleRewriteEnabled: false
+      };
+    },
+    async set(payload) {
+      savedPayload = payload;
+    }
+  };
+
+  const settings = await loadInlineSettings(storage, providerConfig);
+
+  assert.equal(settings.providerId, "openrouter");
+  assert.equal(settings.endpoint, "https://openrouter.ai/api/v1/chat/completions");
+
+  await saveInlineSettings(
+    {
+      providerId: "",
+      endpoint: "https://example.com/compatible/v1",
+      apiKey: "key",
+      model: "demo-model",
+      preference: "",
+      experimentalTitleRewriteEnabled: true
+    },
+    storage,
+    providerConfig
+  );
+
+  assert.deepEqual(savedPayload, {
+    aiProviderPresetId: "custom",
+    aiEndpoint: "https://example.com/compatible/v1/chat/completions",
+    aiApiKey: "key",
+    aiModel: "demo-model",
+    aiPreference: "",
+    experimentalTitleRewriteEnabled: true
+  });
+});


### PR DESCRIPTION
## 变更说明
- 新增 `search-core.js`，把页内浮层和独立搜索窗口共用的结果构建、URL fallback、动作切换等规则收成一层共享模块
- 新增 `search-inline-settings.js`，统一两个搜索入口的内联设置读写逻辑
- `content.js` 和 `search.js` 改为只保留各自的容器渲染、主题差异和交互壳子，删除重复的核心实现
- 补上共享搜索规则、共享设置读写和作用域兼容测试

## 背景
- 之前两个搜索入口各自维护了一份结果构建、动作切换、设置保存和 URL 识别逻辑
- 这会让同一种输入在两个入口里慢慢表现不一致，也让后面修 bug 很容易漏掉另一边

## 验证
- `node --test tests/*.mjs`
- `node --check content.js`
- `node --check search.js`
- `node --check search-core.js`
- `node --check search-inline-settings.js`
- `git diff --check HEAD~1 HEAD`

Closes #15
