### PR TITLE
refactor: 将页内搜索改为按需注入，避免对所有页面常驻注入脚本

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 - 键盘选中搜索结果后，可用右方向键切换“打开 / 关闭”，回车确认
 - 鼠标悬停结果时，会直接显示“打开 / 关闭”按钮
 - 在弹窗里用自然语言筛出一批 tab，然后执行分组、删除、加入书签
+- 普通网页只在真正触发搜索时按需注入页内面板脚本
 - 读取当前窗口里的未固定网页标签页
 - 调用兼容 OpenAI Chat Completions 的 AI 接口
 - 让 AI 生成排序和分组方案
@@ -70,6 +71,7 @@
 
 - `manifest.json`: 扩展权限、弹窗、设置页、快捷键
 - `ai-provider-config.js`: AI 服务商预置和接口归一化逻辑
+- `search-panel-injection.mjs`: 页内搜索面板按需注入时使用的脚本清单
 - `background.js`: AI 调用、排序和 tab group 应用逻辑
 - `background.js`: 也负责自然语言筛选 tab、批量分组/删除/书签
 - `content.js`: 页面内标签页搜索面板

--- a/background.js
+++ b/background.js
@@ -1,3 +1,5 @@
+import { SEARCH_PANEL_INJECTION_FILES } from "./search-panel-injection.mjs";
+
 const DEFAULT_AI_ENDPOINT = "https://api.openai.com/v1/chat/completions";
 const DEFAULT_AI_MODEL = "gpt-4.1-mini";
 const TAB_GROUP_COLORS = ["grey", "blue", "red", "yellow", "green", "pink", "purple", "cyan", "orange"];
@@ -102,7 +104,7 @@ async function openTabSearch() {
     try {
       await chrome.scripting.executeScript({
         target: { tabId: tab.id },
-        files: ["ai-provider-config.js", "content.js"]
+        files: SEARCH_PANEL_INJECTION_FILES
       });
 
       await chrome.tabs.sendMessage(tab.id, payload);

--- a/manifest.json
+++ b/manifest.json
@@ -24,18 +24,6 @@
     "service_worker": "background.js",
     "type": "module"
   },
-  "content_scripts": [
-    {
-      "matches": [
-        "<all_urls>"
-      ],
-      "js": [
-        "ai-provider-config.js",
-        "content.js"
-      ],
-      "run_at": "document_idle"
-    }
-  ],
   "action": {
     "default_popup": "popup.html",
     "default_icon": {

--- a/search-panel-injection.mjs
+++ b/search-panel-injection.mjs
@@ -1,0 +1,1 @@
+export const SEARCH_PANEL_INJECTION_FILES = Object.freeze(["ai-provider-config.js", "content.js"]);

--- a/tests/search-panel-injection.test.mjs
+++ b/tests/search-panel-injection.test.mjs
@@ -1,0 +1,17 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { SEARCH_PANEL_INJECTION_FILES } from "../search-panel-injection.mjs";
+
+const repoRoot = path.resolve(import.meta.dirname, "..");
+
+test("manifest 不再把搜索面板脚本常驻注入到所有页面", () => {
+  const manifest = JSON.parse(fs.readFileSync(path.join(repoRoot, "manifest.json"), "utf8"));
+
+  assert.equal("content_scripts" in manifest, false);
+});
+
+test("按需注入文件清单包含打开页内搜索面板所需脚本", () => {
+  assert.deepEqual(SEARCH_PANEL_INJECTION_FILES, ["ai-provider-config.js", "content.js"]);
+});


### PR DESCRIPTION
## 变更说明
- 删除 `manifest.json` 里对 `<all_urls>` 的搜索面板常驻注入配置
- 新增 `search-panel-injection.mjs`，把后台按需注入用到的脚本清单收成单独模块
- `background.js` 改为统一使用这份按需注入清单
- 补上注入策略测试，并在 README 里说明页内搜索面板改成按需注入

## 背景
- 之前项目同时存在两套策略：一边在 `manifest` 里把搜索脚本打到所有页面，一边又在后台消息失败时按需注入同一套脚本
- 这样会让所有网页都背上不必要的常驻脚本成本，也让真正的主路径不清楚

## 验证
- `node --test tests/*.mjs`
- `node --check background.js`
- `node --check search-panel-injection.mjs`
- `git diff --check HEAD~1 HEAD`

Closes #13
